### PR TITLE
chore: format our golang codes by 'goreturns -l -w .'

### DIFF
--- a/traffic_updater/go/osrm_traffic_updater/get_telenav_traffic.go
+++ b/traffic_updater/go/osrm_traffic_updater/get_telenav_traffic.go
@@ -82,5 +82,5 @@ func flows2map(flows []*proxy.Flow, m map[int64]int) {
 		}
 	}
 
-	fmt.Printf("Load map[wayid] to speed with %d items, %d forward and %d backward.\n", (fwdCnt+bwdCnt), fwdCnt, bwdCnt)
+	fmt.Printf("Load map[wayid] to speed with %d items, %d forward and %d backward.\n", (fwdCnt + bwdCnt), fwdCnt, bwdCnt)
 }

--- a/traffic_updater/go/osrm_traffic_updater/osrm_traffic_updater_test.go
+++ b/traffic_updater/go/osrm_traffic_updater/osrm_traffic_updater_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"testing"
 	"fmt"
+	"testing"
 )
 
 func setChan2True(c chan<- bool) {

--- a/traffic_updater/go/osrm_traffic_updater/speed_table_dumper_test.go
+++ b/traffic_updater/go/osrm_traffic_updater/speed_table_dumper_test.go
@@ -1,16 +1,16 @@
 package main
 
 import (
-	"testing"
-	"os"
-	"log"
-	"fmt"
-	"strconv"
-	"io"
 	"encoding/csv"
+	"fmt"
+	"io"
 	"io/ioutil"
-	"strings"
+	"log"
+	"os"
 	"reflect"
+	"strconv"
+	"strings"
+	"testing"
 
 	"github.com/Telenav/osrm-backend/traffic_updater/go/gen-go/proxy"
 )
@@ -50,7 +50,6 @@ func TestGenerateSingleRecord2(t *testing.T) {
 		t.Error("Test GenerateSingleRecord failed.\n")
 	}
 }
-
 
 func validateStatistic(ds *dumperStatistic, t *testing.T) {
 	sum := ds.Sum()
@@ -105,46 +104,46 @@ type tNodePair struct {
 }
 
 func loadSpeedCsv(f string, m map[tNodePair]int) {
-		// load mock traffic file
-		mockfile, err := os.Open(f)
-		defer mockfile.Close()
+	// load mock traffic file
+	mockfile, err := os.Open(f)
+	defer mockfile.Close()
+	if err != nil {
+		log.Fatal(err)
+		fmt.Printf("Open file of %v failed.\n", f)
+		return
+	}
+	fmt.Printf("Open file of %s succeed.\n", f)
+
+	csvr := csv.NewReader(mockfile)
+	for {
+		row, err := csvr.Read()
 		if err != nil {
-			log.Fatal(err)
-			fmt.Printf("Open file of %v failed.\n", f)
+			if err == io.EOF {
+				err = nil
+				break
+			} else {
+				fmt.Printf("Error during decoding file %s, err = %v\n", f, err)
+				return
+			}
+		}
+
+		var from, to uint64
+		var speed int
+		if from, err = strconv.ParseUint(row[0], 10, 64); err != nil {
+			fmt.Printf("#Error during decoding, row = %v\n", row)
 			return
 		}
-		fmt.Printf("Open file of %s succeed.\n", f)
-
-		csvr := csv.NewReader(mockfile)
-		for {
-			row, err := csvr.Read()
-			if err != nil {
-				if err == io.EOF {
-					err = nil
-					break
-				} else {
-					fmt.Printf("Error during decoding file %s, err = %v\n", f, err)
-					return
-				}
-			}
-
-			var from, to uint64
-			var speed int
-			if from, err = strconv.ParseUint(row[0], 10, 64); err != nil {
-				fmt.Printf("#Error during decoding, row = %v\n", row)
-				return
-			}
-			if to, err = strconv.ParseUint(row[1], 10, 64); err != nil {
-				fmt.Printf("#Error during decoding, row = %v\n", row)
-				return
-			}
-			if speed, err = strconv.Atoi(row[2]); err != nil {
-				fmt.Printf("#Error during decoding, row = %v\n", row)
-				return
-			}
-
-			m[tNodePair{from, to}] = speed
+		if to, err = strconv.ParseUint(row[1], 10, 64); err != nil {
+			fmt.Printf("#Error during decoding, row = %v\n", row)
+			return
 		}
+		if speed, err = strconv.Atoi(row[2]); err != nil {
+			fmt.Printf("#Error during decoding, row = %v\n", row)
+			return
+		}
+
+		m[tNodePair{from, to}] = speed
+	}
 }
 
 func compareFileContentStable(f1, f2 string, t *testing.T) {
@@ -177,4 +176,3 @@ func compareFileContentUnstable(f1, f2 string, t *testing.T) {
 		t.Error("TestLoadWay2Nodeids failed to generate correct map\n")
 	}
 }
-

--- a/traffic_updater/go/osrm_traffic_updater/way2nodeids_loader.go
+++ b/traffic_updater/go/osrm_traffic_updater/way2nodeids_loader.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"time"
+
 	"github.com/golang/snappy"
 )
 
@@ -36,8 +37,7 @@ func load(mappingPath string, data chan<- string) {
 	for scanner.Scan() {
 		data <- (scanner.Text())
 	}
-} 
-
+}
 
 // input data format
 // wayid1, n1, n2
@@ -54,5 +54,3 @@ func convert(data <-chan string, sources [TASKNUM]chan string) {
 		sources[chanIndex] <- str
 	}
 }
-
-

--- a/traffic_updater/go/osrm_traffic_updater/way2nodeids_loader_test.go
+++ b/traffic_updater/go/osrm_traffic_updater/way2nodeids_loader_test.go
@@ -1,11 +1,10 @@
 package main
 
 import (
-	"testing"
 	"reflect"
 	"sync"
+	"testing"
 )
-
 
 func TestLoadWay2Nodeids(t *testing.T) {
 	// load result into sources
@@ -19,7 +18,7 @@ func TestLoadWay2Nodeids(t *testing.T) {
 	allWay2NodesChan := make(chan string, 10000)
 	var wgs sync.WaitGroup
 	wgs.Add(TASKNUM)
-	for i:= 0; i < TASKNUM; i++ {
+	for i := 0; i < TASKNUM; i++ {
 		//fmt.Printf("### current i is %d\n", i)
 		go mergeChannels(sources[i], allWay2NodesChan, &wgs)
 	}
@@ -61,4 +60,3 @@ func generateMockWay2nodeids(way2nodeids map[string]bool) {
 	way2nodeids["24418343,84760849102,84760850102"] = true
 	way2nodeids["24418344,84760846102,84760858102"] = true
 }
-

--- a/traffic_updater/go/snappy_command/snappy_command.go
+++ b/traffic_updater/go/snappy_command/snappy_command.go
@@ -2,19 +2,20 @@ package main
 
 import (
 	"flag"
-	"strings"
 	"fmt"
-	"os"
 	"io"
+	"os"
+	"strings"
+
 	"github.com/golang/snappy"
 )
 
 const snappySuffix string = ".snappy"
 
 var flags struct {
-	input        string
-	output       string
-	suffix       string
+	input  string
+	output string
+	suffix string
 }
 
 func init() {
@@ -48,9 +49,9 @@ func main() {
 	defer fo.Close()
 	defer fo.Sync()
 
-	buf := make([]byte, 128 * 1024)
+	buf := make([]byte, 128*1024)
 	if inputCompressed {
-		_, err := io.CopyBuffer(fo, snappy.NewReader(fi), buf)	
+		_, err := io.CopyBuffer(fo, snappy.NewReader(fi), buf)
 		if err != nil {
 			fmt.Printf("Decompression failed\n")
 		}

--- a/traffic_updater/go/wayid2nodeid_extractor/wayid2nodeids_extractor.go
+++ b/traffic_updater/go/wayid2nodeid_extractor/wayid2nodeids_extractor.go
@@ -156,4 +156,3 @@ func main() {
 	endTime := time.Now()
 	fmt.Printf("Total processing time for wayid2nodeids-extract takes %f seconds\n", endTime.Sub(startTime).Seconds())
 }
-


### PR DESCRIPTION
chore: format our golang codes by 'goreturns -l -w .'
Be noted that we don't need to format generated codes, e.g. generated by thrift

# Issue

What issue is this PR targeting? If there is no issue that addresses the problem, please open a corresponding issue and link it here.
https://github.com/Telenav/osrm-backend/issues/45

Please read our [documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/releasing.md) on release and version management.
If your PR is still work in progress please attach the relevant label.

## Tasklist

 - [ ] review

## Requirements / Relations

 Link any requirements here. Other pull requests this PR is based on?
