### PR TITLE
Feature/speed unit

### DIFF
--- a/profiles/bicycle.lua
+++ b/profiles/bicycle.lua
@@ -263,9 +263,10 @@ function handle_bicycle_tags(profile,way,result,data)
 
   -- other tags
   data.junction = way:get_value_by_key("junction")
-  data.maxspeed = Measure.get_max_speed(way:get_value_by_key ("maxspeed")) or 0
-  data.maxspeed_forward = Measure.get_max_speed(way:get_value_by_key("maxspeed:forward")) or 0
-  data.maxspeed_backward = Measure.get_max_speed(way:get_value_by_key("maxspeed:backward")) or 0
+  data.maxspeed = Measure.get_max_speed(way:get_value_by_key("maxspeed"), way:get_value_by_key("speed_unit")) or 0
+  data.maxspeed_forward = Measure.get_max_speed(way:get_value_by_key("maxspeed:forward"), way:get_value_by_key("speed_unit")) or 0
+  data.maxspeed_backward = Measure.get_max_speed(way:get_value_by_key("maxspeed:backward"), way:get_value_by_key("speed_unit")) or 0
+
   data.barrier = way:get_value_by_key("barrier")
   data.oneway = way:get_value_by_key("oneway")
   data.oneway_bicycle = way:get_value_by_key("oneway:bicycle")

--- a/profiles/lib/measure.lua
+++ b/profiles/lib/measure.lua
@@ -1,4 +1,5 @@
 local Sequence = require('lib/sequence')
+local Sequence = require('lib/set')
 
 Measure = {}
 
@@ -9,12 +10,15 @@ local pound_to_kilograms = 0.45359237
 local miles_to_kilometers = 1.609
 
 -- Parse speed value as kilometers by hours.
-function Measure.parse_value_speed(source)
+function Measure.parse_value_speed(source, speed_unit)
   local n = tonumber(source:match("%d*"))
   if n then
     if string.match(source, "mph") or string.match(source, "mp/h") then
       n = n * miles_to_kilometers
+    elseif speed_unit and speed_unit == "M" then
+      n = n * miles_to_kilometers
     end
+
     return n
   end
 end
@@ -55,9 +59,9 @@ function Measure.parse_value_kilograms(value)
 end
 
 --- Get maxspeed of specified way in kilometers by hours.
-function Measure.get_max_speed(raw_value)
+function Measure.get_max_speed(raw_value, speed_unit)
   if raw_value then
-    return Measure.parse_value_speed(raw_value)
+    return Measure.parse_value_speed(raw_value, speed_unit)
   end
 end
 

--- a/profiles/lib/tags.lua
+++ b/profiles/lib/tags.lua
@@ -2,6 +2,15 @@
 
 local Tags = {}
 
+-- return speed unit values for a specific tag.
+
+function Tags.get_speed_unit_by_key(way, key)
+  local speed_unit = way:get_value_by_key(key)
+
+  return speed_unit
+  
+end
+
 -- return [forward,backward] values for a specific tag.
 -- e.g. for maxspeed search forward:
 --   maxspeed:forward

--- a/profiles/lib/way_handlers.lua
+++ b/profiles/lib/way_handlers.lua
@@ -435,16 +435,12 @@ function WayHandlers.maxspeed(profile,way,result,data)
   local keys = Sequence {  'maxspeed:advisory', 'maxspeed', 'source:maxspeed', 'maxspeed:type' }
   local forward, backward = Tags.get_forward_backward_by_set(way,data,keys)
 
-  local speed_unit = Tags.get_speed_unit_by_key(way, 'speed_unit')
   -- If speed_unit == 'M', then it's mile per hour
   -- If speed_unit == 'K', then it's kilometer per hour
-  local adjust_speed_by_unit = 1
-  if speed_unit == 'M' then
-    adjust_speed_by_unit = 1.60934
-  end
+  local speed_unit = Tags.get_speed_unit_by_key(way, 'speed_unit')
 
-  forward = WayHandlers.parse_maxspeed(forward,profile) * adjust_speed_by_unit
-  backward = WayHandlers.parse_maxspeed(backward,profile) * adjust_speed_by_unit
+  forward = WayHandlers.parse_maxspeed(forward, profile, speed_unit)
+  backward = WayHandlers.parse_maxspeed(backward, profile, speed_unit)
 
   if forward and forward > 0 then
     result.forward_speed = forward * profile.speed_reduction
@@ -455,12 +451,12 @@ function WayHandlers.maxspeed(profile,way,result,data)
   end
 end
 
-function WayHandlers.parse_maxspeed(source,profile)
+function WayHandlers.parse_maxspeed(source, profile, speed_unit)
   if not source then
     return 0
   end
 
-  local n = Measure.get_max_speed(source)
+  local n = Measure.get_max_speed(source, speed_unit)
   if not n then
     -- parse maxspeed like FR:urban
     source = string.lower(source)

--- a/profiles/lib/way_handlers.lua
+++ b/profiles/lib/way_handlers.lua
@@ -434,8 +434,17 @@ end
 function WayHandlers.maxspeed(profile,way,result,data)
   local keys = Sequence {  'maxspeed:advisory', 'maxspeed', 'source:maxspeed', 'maxspeed:type' }
   local forward, backward = Tags.get_forward_backward_by_set(way,data,keys)
-  forward = WayHandlers.parse_maxspeed(forward,profile)
-  backward = WayHandlers.parse_maxspeed(backward,profile)
+
+  local speed_unit = Tags.get_speed_unit_by_key(way, 'speed_unit')
+  -- If speed_unit == 'M', then it's mile per hour
+  -- If speed_unit == 'K', then it's kilometer per hour
+  local adjust_speed_by_unit = 1
+  if speed_unit == 'M' then
+    adjust_speed_by_unit = 1.60934
+  end
+
+  forward = WayHandlers.parse_maxspeed(forward,profile) * adjust_speed_by_unit
+  backward = WayHandlers.parse_maxspeed(backward,profile) * adjust_speed_by_unit
 
   if forward and forward > 0 then
     result.forward_speed = forward * profile.speed_reduction

--- a/profiles/test_speed_unit.lua
+++ b/profiles/test_speed_unit.lua
@@ -1,7 +1,8 @@
-print('hello world')
 
 local tags = require('lib/tags')
+local Measure = require('lib/measure')
 
+-- Test get speed uint by key
 local way = {
     speed_unit = 'M'
 }
@@ -11,12 +12,47 @@ function way:get_value_by_key(k)
 end
 
 local speed_unit = tags.get_speed_unit_by_key(way, 'speed_unit')
+print(speed_unit)
 
--- If speed_unit == 'M', then it's mile per hour
--- If speed_unit == 'K', then it's kilometer per hour
-local adjust_speed_by_unit = 1
-if speed_unit == 'M' then
-    adjust_speed_by_unit = 1.60934
-end
+-- Test cases:
+-- 1. speed without unit + speed unit in mile per hour
+local source = "50"
+speed_unit = "M"
 
-print(speed_unit, adjust_speed_by_unit)
+local n = Measure.get_max_speed(source, speed_unit)
+print(n)
+
+-- 2. speed without unit + speed unit in kilometer per hour
+source = "50"
+speed_unit = "K"
+
+n = Measure.get_max_speed(source, speed_unit)
+print(n)
+
+-- 3. speed with unit + speed unit in mile per hour
+source = "50 mph"
+speed_unit = "M"
+
+n = Measure.get_max_speed(source, speed_unit)
+print(n)
+
+-- 4. speed with unit + speed unit in kilometer per hour
+source = "50 mph"
+speed_unit = "K"
+
+n = Measure.get_max_speed(source, speed_unit)
+print(n)
+
+-- 5. speed with unit + speed unit in kilometer per hour
+source = "50 kph"
+speed_unit = "K"
+
+n = Measure.get_max_speed(source, speed_unit)
+print(n)
+
+-- 6. speed with unit + speed unit in mile per hour
+source = "50 kph"
+speed_unit = "M"
+
+n = Measure.get_max_speed(source, speed_unit)
+print(n)

--- a/profiles/test_speed_unit.lua
+++ b/profiles/test_speed_unit.lua
@@ -1,0 +1,22 @@
+print('hello world')
+
+local tags = require('lib/tags')
+
+local way = {
+    speed_unit = 'M'
+}
+
+function way:get_value_by_key(k)
+    return self[k]
+end
+
+local speed_unit = tags.get_speed_unit_by_key(way, 'speed_unit')
+
+-- If speed_unit == 'M', then it's mile per hour
+-- If speed_unit == 'K', then it's kilometer per hour
+local adjust_speed_by_unit = 1
+if speed_unit == 'M' then
+    adjust_speed_by_unit = 1.60934
+end
+
+print(speed_unit, adjust_speed_by_unit)


### PR DESCRIPTION
For Telenav internal data, an additional attribute, speed unit, (e.g. maxspeed=50, speed_unit=M) should be consider to identify between mile/hour and kilometer/hour.

After discussed, change max speed parser function to take speed unit as parameters