### PR TITLE
Feature/traffic sign

### DIFF
--- a/profiles/CHANGELOG.md
+++ b/profiles/CHANGELOG.md
@@ -1,37 +1,24 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to profiles will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## [Unreleased]
-
 ## 2020-03-17
 
-### Added
-
-- README.md
-- CHANGELOG.md
-- Parser to parse traffic signals when process node for unidb in lib-unidb/relations.lua 
-- type of traffic_signals in relation_types in car-unidb.lua to load relations when it contains traffic signals. 
-
-### Removed
-- type of route in relations_types in car-unidb.lua since there is no type of route in unidb
+- Added README.md [#232](https://github.com/Telenav/osrm-backend/pull/232)
+- Added CHANGELOG.md [#232](https://github.com/Telenav/osrm-backend/pull/232)
+- Added a parser to parse traffic signals when process node for unidb in lib-unidb/relations.lua [#232](https://github.com/Telenav/osrm-backend/pull/232)
+- Added traffic_signals in relation_types in car-unidb.lua to load relations when it contains traffic signals [#232](https://github.com/Telenav/osrm-backend/pull/232)
+- Removed route in relations_types in car-unidb.lua since there is no type of route in unidb [#232](https://github.com/Telenav/osrm-backend/pull/232)
 
 ## 2020-03-15
 
-### Changed
-
-- Revert PR-67 to keep car.lua and lib/* are the same as before
-
-### Removed
-
-- test_speed_unit.lua which is unneccessary
+- Changed to revert PR-67 to keep car.lua and lib/* are the same as before [#228](https://github.com/Telenav/osrm-backend/pull/228)
+- Removed test_speed_unit.lua which is unneccessary [#228](https://github.com/Telenav/osrm-backend/pull/228)
 
 ## 2020-03-11
 
-### Added
-
-- lib-unidb to hold all scripts related to unidb
-- car-unidb.lua to support unidb for car style
+- Added lib-unidb to hold all scripts related to unidb [#214](https://github.com/Telenav/osrm-backend/pull/214)
+- Added car-unidb.lua to support unidb for car style [#214](https://github.com/Telenav/osrm-backend/pull/214)
 

--- a/profiles/CHANGELOG.md
+++ b/profiles/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+## [Unreleased]
+
+## 2020-03-17
+
+### Added
+
+- README.md
+- CHANGELOG.md
+- Parser to parse traffic signals when process node for unidb in lib-unidb/relations.lua 
+- type of traffic_signals in relation_types in car-unidb.lua to load relations when it contains traffic signals. 
+
+### Removed
+- type of route in relations_types in car-unidb.lua since there is no type of route in unidb
+
+## 2020-03-15
+
+### Changed
+
+- Revert PR-67 to keep car.lua and lib/* are the same as before
+
+### Removed
+
+- test_speed_unit.lua which is unneccessary
+
+## 2020-03-11
+
+### Added
+
+- lib-unidb to hold all scripts related to unidb
+- car-unidb.lua to support unidb for car style
+

--- a/profiles/CHANGELOG.md
+++ b/profiles/CHANGELOG.md
@@ -1,24 +1,24 @@
 # Changelog
 
-All notable changes to profiles will be documented in this file.
+All notable changes to profiles will be documented in this file.All sentences start with ADDED, REMOVED, CHANGED, or FIXED
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## 2020-03-17
 
-- Added README.md [#232](https://github.com/Telenav/osrm-backend/pull/232)
-- Added CHANGELOG.md [#232](https://github.com/Telenav/osrm-backend/pull/232)
-- Added a parser to parse traffic signals when process node for unidb in lib-unidb/relations.lua [#232](https://github.com/Telenav/osrm-backend/pull/232)
-- Added traffic_signals in relation_types in car-unidb.lua to load relations when it contains traffic signals [#232](https://github.com/Telenav/osrm-backend/pull/232)
-- Removed route in relations_types in car-unidb.lua since there is no type of route in unidb [#232](https://github.com/Telenav/osrm-backend/pull/232)
+- ADDED README.md [#232](https://github.com/Telenav/osrm-backend/pull/232)
+- ADDED CHANGELOG.md [#232](https://github.com/Telenav/osrm-backend/pull/232)
+- ADDED a parser to parse traffic signals when process node for unidb in lib-unidb/relations.lua [#232](https://github.com/Telenav/osrm-backend/pull/232)
+- ADDED traffic_signals in relation_types in car-unidb.lua to load relations when it contains traffic signals [#232](https://github.com/Telenav/osrm-backend/pull/232)
+- REMOVED route in relations_types in car-unidb.lua since there is no type of route in unidb [#232](https://github.com/Telenav/osrm-backend/pull/232)
 
 ## 2020-03-15
 
-- Changed to revert PR-67 to keep car.lua and lib/* are the same as before [#228](https://github.com/Telenav/osrm-backend/pull/228)
-- Removed test_speed_unit.lua which is unneccessary [#228](https://github.com/Telenav/osrm-backend/pull/228)
+- CHANGED to revert PR-67 to keep car.lua and lib/* are the same as before [#228](https://github.com/Telenav/osrm-backend/pull/228)
+- REMOVED test_speed_unit.lua which is unneccessary [#228](https://github.com/Telenav/osrm-backend/pull/228)
 
 ## 2020-03-11
 
-- Added lib-unidb to hold all scripts related to unidb [#214](https://github.com/Telenav/osrm-backend/pull/214)
-- Added car-unidb.lua to support unidb for car style [#214](https://github.com/Telenav/osrm-backend/pull/214)
+- ADDED lib-unidb to hold all scripts related to unidb [#214](https://github.com/Telenav/osrm-backend/pull/214)
+- ADDED car-unidb.lua to support unidb for car style [#214](https://github.com/Telenav/osrm-backend/pull/214)
 

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -1,0 +1,15 @@
+# Profile
+
+Lua scripts for preprocess map data
+
+## Getting Started
+
+### Naming format
+```
+All unidb related scprits or directories should be named xxx-unidb.lua or xxx-unidb/*
+```
+
+### Code Structure
+```
+1) car-unidb.lua is for map data of unidb only
+2) lib-unidb is the library for map data of unidb only

--- a/profiles/car-unidb.lua
+++ b/profiles/car-unidb.lua
@@ -348,14 +348,12 @@ function process_node(profile, node, result, relations)
   end
 
   -- check if node is a traffic light
-  local tag = node:get_value_by_key("highway")
-  if "traffic_signals" == tag then
-    result.traffic_lights = true
-  end
-  -- local tag = relations:get_value_by_key("type")
+  -- local tag = node:get_value_by_key("highway")
   -- if "traffic_signals" == tag then
   --   result.traffic_lights = true
   -- end
+  Relations.process_node_refs(node, relations, result)
+  
 end
 
 function process_way(profile, way, result, relations)

--- a/profiles/car-unidb.lua
+++ b/profiles/car-unidb.lua
@@ -306,8 +306,7 @@ function setup()
     },
 
     relation_types = Sequence {
-      "route",
-      "traffic_sign"
+      "traffic_signals"
     },
 
     -- classify highway tags when necessary for turn weights

--- a/profiles/car-unidb.lua
+++ b/profiles/car-unidb.lua
@@ -347,10 +347,6 @@ function process_node(profile, node, result, relations)
   end
 
   -- check if node is a traffic light
-  -- local tag = node:get_value_by_key("highway")
-  -- if "traffic_signals" == tag then
-  --   result.traffic_lights = true
-  -- end
   Relations.process_node_refs(node, relations, result)
   
 end

--- a/profiles/lib-unidb/relations.lua
+++ b/profiles/lib-unidb/relations.lua
@@ -259,4 +259,24 @@ function Relations.process_way_refs(way, relations, result)
   end
 end
 
+function Relations.parse_traffic_sign(rel)
+  local t = rel:get_value_by_key("type")
+  if t == "traffic_sign" then
+    return true
+  else
+    return false
+  end
+
+end
+
+function Relations.process_node_refs(node, relations, result)
+  local parsed_rel_list = {}
+  local rel_id_list = relations:get_relations(node)
+  for i, rel_id in ipairs(rel_id_list) do
+    local rel = relations:relation(rel_id)
+    result.traffic_lights = Relations.parse_traffic_sign(rel)
+  end
+
+end
+
 return Relations

--- a/profiles/lib-unidb/relations.lua
+++ b/profiles/lib-unidb/relations.lua
@@ -259,9 +259,9 @@ function Relations.process_way_refs(way, relations, result)
   end
 end
 
-function Relations.parse_traffic_sign(rel)
+function Relations.parse_traffic_signals(rel)
   local t = rel:get_value_by_key("type")
-  if t == "traffic_sign" then
+  if t == "traffic_signals" then
     return true
   else
     return false
@@ -274,7 +274,10 @@ function Relations.process_node_refs(node, relations, result)
   local rel_id_list = relations:get_relations(node)
   for i, rel_id in ipairs(rel_id_list) do
     local rel = relations:relation(rel_id)
-    result.traffic_lights = Relations.parse_traffic_sign(rel)
+    if Relations.parse_traffic_signals(rel) then
+      result.traffic_lights = true
+      return
+    end
   end
 
 end


### PR DESCRIPTION
# Issue

In OSM data "traffic signals" is an attributes on node, but in Unidb data "traffic signals" is an attributes on relations.

When process node, need to parse relations to get info of traffic signals. 

Modify scripts to support retrieve traffic signals info from relations when process node.