### PR TITLE
Improve Release Actions

### DIFF
--- a/.github/workflows/release-go-cmd-oasis.yml
+++ b/.github/workflows/release-go-cmd-oasis.yml
@@ -16,13 +16,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux, windows, darwin]
-        goarch: ["386", amd64]
-        exclude:  
-          # windows/386 and darwin/386 seems useless 
-          - goarch: "386"
-            goos: windows 
-          - goarch: "386"
-            goos: darwin 
+        goarch: [amd64]
     steps:
     - uses: actions/checkout@v2
     - uses: wangyoucao577/go-release-action@v1.2

--- a/.github/workflows/release-go-cmd-osrm-files-extractor.yml
+++ b/.github/workflows/release-go-cmd-osrm-files-extractor.yml
@@ -16,13 +16,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux, windows, darwin]
-        goarch: ["386", amd64]
-        exclude:  
-          # windows/386 and darwin/386 seems useless 
-          - goarch: "386"
-            goos: windows 
-          - goarch: "386"
-            goos: darwin 
+        goarch: [amd64]
     steps:
     - uses: actions/checkout@v2
     - uses: wangyoucao577/go-release-action@v1.2

--- a/.github/workflows/release-go-cmd-traffixproxy-cli.yml
+++ b/.github/workflows/release-go-cmd-traffixproxy-cli.yml
@@ -16,13 +16,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux, windows, darwin]
-        goarch: ["386", amd64]
-        exclude:  
-          # windows/386 and darwin/386 seems useless 
-          - goarch: "386"
-            goos: windows 
-          - goarch: "386"
-            goos: darwin 
+        goarch: [amd64]
     steps:
     - uses: actions/checkout@v2
     - uses: wangyoucao577/go-release-action@v1.2

--- a/.github/workflows/release-osrm-backend.yml
+++ b/.github/workflows/release-osrm-backend.yml
@@ -3,7 +3,7 @@ name: Release Docker - osrm-backend
 on: 
   push:
     tags:
-    - 'osrm-backend/**'
+    - 'v*' # semver, e.g., v10.1.0
 
 env:
   IMAGE_NAME: osrm-backend


### PR DESCRIPTION
# Issue

Closes https://github.com/Telenav/osrm-backend/issues/251 https://github.com/Telenav/osrm-backend/issues/252

- Remove `linux-386` when release go binaries; 
- Follow our proposal to release osrm-backend(follow semver, start from `v10.0.1`). 