### PR TITLE
feat:implement local station finder based on google:s2 indexer

### DIFF
--- a/integration/cmd/oasis/flags.go
+++ b/integration/cmd/oasis/flags.go
@@ -11,6 +11,7 @@ var flags struct {
 	tnSearchEndpoint     string
 	tnSearchAPIKey       string
 	tnSearchAPISignature string
+	localDataPath        string
 }
 
 func init() {
@@ -19,5 +20,6 @@ func init() {
 	flag.StringVar(&flags.finderType, "finder", "", "Specify search finder to search for nearby charge stations for given location, use TNSearchFinder or LocalIndexerFinder")
 	flag.StringVar(&flags.tnSearchEndpoint, "search", "", "TN-Search-backend endpoint")
 	flag.StringVar(&flags.tnSearchAPIKey, "searchApiKey", "", "API key for TN-Search-backend")
-	flag.StringVar(&flags.tnSearchAPISignature, "searchApiSignature", "", "API Signature for  TN-Search-backend")
+	flag.StringVar(&flags.tnSearchAPISignature, "searchApiSignature", "", "API Signature for TN-Search-backend")
+	flag.StringVar(&flags.localDataPath, "datapath", "", "Local data path for index data")
 }

--- a/integration/cmd/oasis/main.go
+++ b/integration/cmd/oasis/main.go
@@ -14,7 +14,8 @@ func main() {
 	defer glog.Flush()
 	mux := http.NewServeMux()
 
-	oasisService, err := oasis.New(flags.osrmBackendEndpoint, flags.finderType, flags.tnSearchEndpoint, flags.tnSearchAPIKey, flags.tnSearchAPISignature)
+	oasisService, err := oasis.New(flags.osrmBackendEndpoint, flags.finderType, flags.tnSearchEndpoint,
+		flags.tnSearchAPIKey, flags.tnSearchAPISignature, flags.localDataPath)
 	if err != nil {
 		glog.Errorf("Failed to create oasis handler due to err %+v.\n", err)
 		return

--- a/integration/service/oasis/handler.go
+++ b/integration/service/oasis/handler.go
@@ -19,7 +19,7 @@ type Handler struct {
 }
 
 // New creates new Handler object
-func New(osrmBackend, finderType, searchEndpoint, apiKey, apiSignature string) (*Handler, error) {
+func New(osrmBackend, finderType, searchEndpoint, apiKey, apiSignature, dataFolderPath string) (*Handler, error) {
 	// @todo: need make sure connectivity is on and continues available
 	//        simple request to guarantee server is alive after init
 	if len(osrmBackend) == 0 {
@@ -27,7 +27,7 @@ func New(osrmBackend, finderType, searchEndpoint, apiKey, apiSignature string) (
 		return nil, err
 	}
 
-	finder, err := stationfinder.CreateStationsFinder(finderType, searchEndpoint, apiKey, apiSignature)
+	finder, err := stationfinder.CreateStationsFinder(finderType, searchEndpoint, apiKey, apiSignature, dataFolderPath)
 	if err != nil {
 		glog.Errorf("Failed in Handler's New() when try to call CreateStationsFinder(), met error = %+v\n", err)
 		return nil, err

--- a/integration/service/oasis/spatialindexer/interface_mock.go
+++ b/integration/service/oasis/spatialindexer/interface_mock.go
@@ -1,6 +1,7 @@
 package spatialindexer
 
-var mockPlaceInfo1 = []*PointInfo{
+// MockPlaceInfo1 contains 10 PointInfo items
+var MockPlaceInfo1 = []*PointInfo{
 	&PointInfo{
 		ID: 1,
 		Location: Location{
@@ -78,9 +79,9 @@ type MockFinder struct {
 }
 
 // FindNearByPointIDs returns mock result
-// It returns 10 places defined in mockPlaceInfo1
+// It returns 10 places defined in MockPlaceInfo1
 func (finder *MockFinder) FindNearByPointIDs(center Location, radius float64, limitCount int) []*PointInfo {
-	return mockPlaceInfo1
+	return MockPlaceInfo1
 }
 
 // MockPointsIterator implements PointsIterator's interface
@@ -89,10 +90,10 @@ type MockPointsIterator struct {
 
 // IteratePoints() iterate places with mock data
 func (iterator *MockPointsIterator) IteratePoints() <-chan PointInfo {
-	pointInfoC := make(chan PointInfo, len(mockPlaceInfo1))
+	pointInfoC := make(chan PointInfo, len(MockPlaceInfo1))
 
 	go func() {
-		for _, item := range mockPlaceInfo1 {
+		for _, item := range MockPlaceInfo1 {
 			pointInfoC <- *item
 		}
 

--- a/integration/service/oasis/stationfinder/cloudfinder/basic_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/basic_finder.go
@@ -37,6 +37,7 @@ func (bf *basicFinder) getNearbyChargeStations(req *nearbychargestation.Request)
 	bf.searchRespLock.Unlock()
 }
 
+// NearbyStationsIterator provides channel which contains near by station information
 func (bf *basicFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
 	if bf.searchResp == nil || len(bf.searchResp.Results) == 0 {
 		c := make(chan *stationfindertype.ChargeStationInfo)

--- a/integration/service/oasis/stationfinder/cloudfinder/basic_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/basic_finder.go
@@ -1,4 +1,4 @@
-package tnsearchfinder
+package cloudfinder
 
 import (
 	"sync"

--- a/integration/service/oasis/stationfinder/cloudfinder/basic_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/basic_finder.go
@@ -37,9 +37,9 @@ func (bf *basicFinder) getNearbyChargeStations(req *nearbychargestation.Request)
 	bf.searchRespLock.Unlock()
 }
 
-func (bf *basicFinder) IterateNearbyStations() <-chan stationfindertype.ChargeStationInfo {
+func (bf *basicFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
 	if bf.searchResp == nil || len(bf.searchResp.Results) == 0 {
-		c := make(chan stationfindertype.ChargeStationInfo)
+		c := make(chan *stationfindertype.ChargeStationInfo)
 		go func() {
 			defer close(c)
 		}()
@@ -52,7 +52,7 @@ func (bf *basicFinder) IterateNearbyStations() <-chan stationfindertype.ChargeSt
 	copy(results, bf.searchResp.Results)
 	bf.searchRespLock.RUnlock()
 
-	c := make(chan stationfindertype.ChargeStationInfo, size)
+	c := make(chan *stationfindertype.ChargeStationInfo, size)
 	go func() {
 		defer close(c)
 		for _, result := range results {
@@ -65,7 +65,7 @@ func (bf *basicFinder) IterateNearbyStations() <-chan stationfindertype.ChargeSt
 					Lat: result.Place.Address[0].GeoCoordinate.Latitude,
 					Lon: result.Place.Address[0].GeoCoordinate.Longitude},
 			}
-			c <- station
+			c <- &station
 		}
 	}()
 

--- a/integration/service/oasis/stationfinder/cloudfinder/basic_finder_test.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/basic_finder_test.go
@@ -1,4 +1,4 @@
-package tnsearchfinder
+package cloudfinder
 
 import (
 	"reflect"

--- a/integration/service/oasis/stationfinder/cloudfinder/basic_finder_test.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/basic_finder_test.go
@@ -10,29 +10,29 @@ import (
 	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
 )
 
-var mockChargeStationInfo1 []stationfindertype.ChargeStationInfo = []stationfindertype.ChargeStationInfo{
-	stationfindertype.ChargeStationInfo{
+var mockChargeStationInfo1 = []*stationfindertype.ChargeStationInfo{
+	{
 		ID: "station1",
 		Location: nav.Location{
 			Lat: 32.333,
 			Lon: 122.333,
 		},
 	},
-	stationfindertype.ChargeStationInfo{
+	{
 		ID: "station2",
 		Location: nav.Location{
 			Lat: -32.333,
 			Lon: -122.333,
 		},
 	},
-	stationfindertype.ChargeStationInfo{
+	{
 		ID: "station3",
 		Location: nav.Location{
 			Lat: 32.333,
 			Lon: -122.333,
 		},
 	},
-	stationfindertype.ChargeStationInfo{
+	{
 		ID: "station4",
 		Location: nav.Location{
 			Lat: -32.333,
@@ -41,22 +41,22 @@ var mockChargeStationInfo1 []stationfindertype.ChargeStationInfo = []stationfind
 	},
 }
 
-var mockChargeStationInfo2 []stationfindertype.ChargeStationInfo = []stationfindertype.ChargeStationInfo{
-	stationfindertype.ChargeStationInfo{
+var mockChargeStationInfo2 = []*stationfindertype.ChargeStationInfo{
+	{
 		ID: "station1",
 		Location: nav.Location{
 			Lat: 32.333,
 			Lon: 122.333,
 		},
 	},
-	stationfindertype.ChargeStationInfo{
+	{
 		ID: "station2",
 		Location: nav.Location{
 			Lat: -32.333,
 			Lon: -122.333,
 		},
 	},
-	stationfindertype.ChargeStationInfo{
+	{
 		ID: "station5",
 		Location: nav.Location{
 			Lat: -12.333,
@@ -65,15 +65,15 @@ var mockChargeStationInfo2 []stationfindertype.ChargeStationInfo = []stationfind
 	},
 }
 
-var mockChargeStationInfo3 []stationfindertype.ChargeStationInfo = []stationfindertype.ChargeStationInfo{
-	stationfindertype.ChargeStationInfo{
+var mockChargeStationInfo3 = []*stationfindertype.ChargeStationInfo{
+	{
 		ID: "station6",
 		Location: nav.Location{
 			Lat: 30.333,
 			Lon: 122.333,
 		},
 	},
-	stationfindertype.ChargeStationInfo{
+	{
 		ID: "station7",
 		Location: nav.Location{
 			Lat: -10.333,
@@ -85,7 +85,7 @@ var mockChargeStationInfo3 []stationfindertype.ChargeStationInfo = []stationfind
 func TestBasicFinderCorrectness(t *testing.T) {
 	cases := []struct {
 		input  []*nearbychargestation.Result
-		expect []stationfindertype.ChargeStationInfo
+		expect []*stationfindertype.ChargeStationInfo
 	}{
 		{
 			nearbychargestation.MockSearchResponse1.Results,
@@ -105,7 +105,7 @@ func TestBasicFinderCorrectness(t *testing.T) {
 			wg.Add(1)
 			defer wg.Done()
 
-			var r []stationfindertype.ChargeStationInfo
+			var r []*stationfindertype.ChargeStationInfo
 			for item := range c {
 				r = append(r, item)
 			}
@@ -122,7 +122,7 @@ func TestBasicFinderAsync(t *testing.T) {
 	cases := []struct {
 		input     []*nearbychargestation.Result
 		inputLock *sync.RWMutex
-		expect    []stationfindertype.ChargeStationInfo
+		expect    []*stationfindertype.ChargeStationInfo
 	}{
 		{
 			nearbychargestation.MockSearchResponse1.Results,
@@ -145,7 +145,7 @@ func TestBasicFinderAsync(t *testing.T) {
 				c := bf.IterateNearbyStations()
 				go func(wg *sync.WaitGroup) {
 					defer wg.Done()
-					var r []stationfindertype.ChargeStationInfo
+					var r []*stationfindertype.ChargeStationInfo
 					for item := range c {
 						r = append(r, item)
 					}

--- a/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder.go
@@ -43,6 +43,7 @@ func (sf *destStationFinder) prepare() {
 	return
 }
 
+// NearbyStationsIterator provides channel which contains near by station information for dest
 func (sf *destStationFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
 	return sf.bf.IterateNearbyStations()
 }

--- a/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder.go
@@ -43,6 +43,6 @@ func (sf *destStationFinder) prepare() {
 	return
 }
 
-func (sf *destStationFinder) IterateNearbyStations() <-chan stationfindertype.ChargeStationInfo {
+func (sf *destStationFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
 	return sf.bf.IterateNearbyStations()
 }

--- a/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder.go
@@ -1,4 +1,4 @@
-package tnsearchfinder
+package cloudfinder
 
 import (
 	"sync"

--- a/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder_mock.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder_mock.go
@@ -1,4 +1,4 @@
-package tnsearchfinder
+package cloudfinder
 
 import (
 	"sync"
@@ -6,9 +6,9 @@ import (
 	"github.com/Telenav/osrm-backend/integration/pkg/api/search/nearbychargestation"
 )
 
-// CreateMockOrigStationFinder1 creates mock orig station finder with nearbychargestation.MockSearchResponse1
-func CreateMockOrigStationFinder1() *origStationFinder {
-	obj := &origStationFinder{
+// CreateMockDestStationFinder1 creates mock dest station finder with nearbychargestation.MockSearchResponse1
+func CreateMockDestStationFinder1() *destStationFinder {
+	obj := &destStationFinder{
 		oasisReq: nil,
 		bf: &basicFinder{
 			tnSearchConnector: nil,
@@ -19,9 +19,9 @@ func CreateMockOrigStationFinder1() *origStationFinder {
 	return obj
 }
 
-// CreateMockOrigStationFinder2 creates mock orig station finder with nearbychargestation.MockSearchResponse2
-func CreateMockOrigStationFinder2() *origStationFinder {
-	obj := &origStationFinder{
+// CreateMockDestStationFinder2 creates mock dest station finder with nearbychargestation.MockSearchResponse2
+func createMockDestStationFinder2() *destStationFinder {
+	obj := &destStationFinder{
 		oasisReq: nil,
 		bf: &basicFinder{
 			tnSearchConnector: nil,
@@ -32,9 +32,9 @@ func CreateMockOrigStationFinder2() *origStationFinder {
 	return obj
 }
 
-// CreateMockOrigStationFinder3 creates mock orig station finder with nearbychargestation.MockSearchResponse3
-func CreateMockOrigStationFinder3() *origStationFinder {
-	obj := &origStationFinder{
+// CreateMockDestStationFinder3 creates mock dest station finder with nearbychargestation.MockSearchResponse3
+func createMockDestStationFinder3() *destStationFinder {
+	obj := &destStationFinder{
 		oasisReq: nil,
 		bf: &basicFinder{
 			tnSearchConnector: nil,

--- a/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder_test.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder_test.go
@@ -1,4 +1,4 @@
-package tnsearchfinder
+package cloudfinder
 
 import (
 	"reflect"

--- a/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder_test.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder_test.go
@@ -10,7 +10,7 @@ import (
 func TestDestStationFinderIterator(t *testing.T) {
 	sf := CreateMockDestStationFinder1()
 	c := sf.IterateNearbyStations()
-	var r []stationfindertype.ChargeStationInfo
+	var r []*stationfindertype.ChargeStationInfo
 	go func() {
 		for item := range c {
 			r = append(r, item)

--- a/integration/service/oasis/stationfinder/cloudfinder/doc.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/doc.go
@@ -1,0 +1,4 @@
+/*
+Package cloudfinder provides spatial query based on Telenav's cloud web service.
+*/
+package cloudfinder

--- a/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder.go
@@ -1,4 +1,4 @@
-package tnsearchfinder
+package cloudfinder
 
 import (
 	"github.com/Telenav/osrm-backend/integration/pkg/api/nav"

--- a/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder.go
@@ -36,6 +36,7 @@ func (sf *lowEnergyLocationStationFinder) prepare() {
 	return
 }
 
+// NearbyStationsIterator provides channel which contains near by station information for low energy location
 func (sf *lowEnergyLocationStationFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
 	return sf.bf.IterateNearbyStations()
 }

--- a/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder.go
@@ -8,7 +8,8 @@ import (
 	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
 )
 
-const lowEnergyLocationCandidateNumber = 20
+// LowEnergyLocationCandidateNumber indicates how much charge station to be searched for low energy point
+const LowEnergyLocationCandidateNumber = 20
 
 type lowEnergyLocationStationFinder struct {
 	location *nav.Location
@@ -29,12 +30,12 @@ func (sf *lowEnergyLocationStationFinder) prepare() {
 		searchcoordinate.Coordinate{
 			Lat: sf.location.Lat,
 			Lon: sf.location.Lon},
-		lowEnergyLocationCandidateNumber,
+		LowEnergyLocationCandidateNumber,
 		-1)
 	sf.bf.getNearbyChargeStations(req)
 	return
 }
 
-func (sf *lowEnergyLocationStationFinder) IterateNearbyStations() <-chan stationfindertype.ChargeStationInfo {
+func (sf *lowEnergyLocationStationFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
 	return sf.bf.IterateNearbyStations()
 }

--- a/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder_mock.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder_mock.go
@@ -1,4 +1,4 @@
-package tnsearchfinder
+package cloudfinder
 
 import (
 	"sync"

--- a/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder_test.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder_test.go
@@ -1,4 +1,4 @@
-package tnsearchfinder
+package cloudfinder
 
 import (
 	"reflect"

--- a/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder_test.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder_test.go
@@ -17,7 +17,7 @@ func TestLowEnergyLocationStationFinderIterator1(t *testing.T) {
 		defer wg.Done()
 
 		c := sf.IterateNearbyStations()
-		var r []stationfindertype.ChargeStationInfo
+		var r []*stationfindertype.ChargeStationInfo
 
 		for item := range c {
 			r = append(r, item)
@@ -37,7 +37,7 @@ func TestLowEnergyLocationStationFinderIterator2(t *testing.T) {
 		defer wg.Done()
 
 		c := sf.IterateNearbyStations()
-		var r []stationfindertype.ChargeStationInfo
+		var r []*stationfindertype.ChargeStationInfo
 		for item := range c {
 			r = append(r, item)
 		}
@@ -56,7 +56,7 @@ func TestLowEnergyLocationStationFinderIterator3(t *testing.T) {
 		defer wg.Done()
 
 		c := sf.IterateNearbyStations()
-		var r []stationfindertype.ChargeStationInfo
+		var r []*stationfindertype.ChargeStationInfo
 		for item := range c {
 			r = append(r, item)
 		}

--- a/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder.go
@@ -1,4 +1,4 @@
-package tnsearchfinder
+package cloudfinder
 
 import (
 	"github.com/Telenav/osrm-backend/integration/pkg/api/oasis"

--- a/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder.go
@@ -37,6 +37,6 @@ func (sf *origStationFinder) prepare() {
 	return
 }
 
-func (sf *origStationFinder) IterateNearbyStations() <-chan stationfindertype.ChargeStationInfo {
+func (sf *origStationFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
 	return sf.bf.IterateNearbyStations()
 }

--- a/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder.go
@@ -37,6 +37,7 @@ func (sf *origStationFinder) prepare() {
 	return
 }
 
+// NearbyStationsIterator provides channel which contains near by station information for orig
 func (sf *origStationFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
 	return sf.bf.IterateNearbyStations()
 }

--- a/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder_mock.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder_mock.go
@@ -1,4 +1,4 @@
-package tnsearchfinder
+package cloudfinder
 
 import (
 	"sync"
@@ -6,9 +6,9 @@ import (
 	"github.com/Telenav/osrm-backend/integration/pkg/api/search/nearbychargestation"
 )
 
-// CreateMockDestStationFinder1 creates mock dest station finder with nearbychargestation.MockSearchResponse1
-func CreateMockDestStationFinder1() *destStationFinder {
-	obj := &destStationFinder{
+// CreateMockOrigStationFinder1 creates mock orig station finder with nearbychargestation.MockSearchResponse1
+func CreateMockOrigStationFinder1() *origStationFinder {
+	obj := &origStationFinder{
 		oasisReq: nil,
 		bf: &basicFinder{
 			tnSearchConnector: nil,
@@ -19,9 +19,9 @@ func CreateMockDestStationFinder1() *destStationFinder {
 	return obj
 }
 
-// CreateMockDestStationFinder2 creates mock dest station finder with nearbychargestation.MockSearchResponse2
-func createMockDestStationFinder2() *destStationFinder {
-	obj := &destStationFinder{
+// CreateMockOrigStationFinder2 creates mock orig station finder with nearbychargestation.MockSearchResponse2
+func CreateMockOrigStationFinder2() *origStationFinder {
+	obj := &origStationFinder{
 		oasisReq: nil,
 		bf: &basicFinder{
 			tnSearchConnector: nil,
@@ -32,9 +32,9 @@ func createMockDestStationFinder2() *destStationFinder {
 	return obj
 }
 
-// CreateMockDestStationFinder3 creates mock dest station finder with nearbychargestation.MockSearchResponse3
-func createMockDestStationFinder3() *destStationFinder {
-	obj := &destStationFinder{
+// CreateMockOrigStationFinder3 creates mock orig station finder with nearbychargestation.MockSearchResponse3
+func CreateMockOrigStationFinder3() *origStationFinder {
+	obj := &origStationFinder{
 		oasisReq: nil,
 		bf: &basicFinder{
 			tnSearchConnector: nil,

--- a/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder_test.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder_test.go
@@ -1,4 +1,4 @@
-package tnsearchfinder
+package cloudfinder
 
 import (
 	"reflect"
@@ -11,6 +11,8 @@ func TestOrigStationFinderIterator(t *testing.T) {
 	sf := CreateMockOrigStationFinder1()
 	c := sf.IterateNearbyStations()
 	var r []stationfindertype.ChargeStationInfo
+
+	isdoneC := make(chan bool)
 	go func() {
 		for item := range c {
 			r = append(r, item)
@@ -19,5 +21,7 @@ func TestOrigStationFinderIterator(t *testing.T) {
 		if !reflect.DeepEqual(r, mockChargeStationInfo1) {
 			t.Errorf("expect %v but got %v", mockChargeStationInfo1, r)
 		}
+		isdoneC <- true
 	}()
+	<-isdoneC
 }

--- a/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder_test.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder_test.go
@@ -10,7 +10,7 @@ import (
 func TestOrigStationFinderIterator(t *testing.T) {
 	sf := CreateMockOrigStationFinder1()
 	c := sf.IterateNearbyStations()
-	var r []stationfindertype.ChargeStationInfo
+	var r []*stationfindertype.ChargeStationInfo
 
 	isdoneC := make(chan bool)
 	go func() {

--- a/integration/service/oasis/stationfinder/cloudfinder/tnsearch_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/tnsearch_station_finder.go
@@ -1,4 +1,4 @@
-package tnsearchfinder
+package cloudfinder
 
 import (
 	"github.com/Telenav/osrm-backend/integration/pkg/api/nav"
@@ -11,8 +11,8 @@ type tnSearchStationFinder struct {
 	sc *searchconnector.TNSearchConnector
 }
 
-// NewTnSearchStationFinder creates finder based on telenav search
-func NewTnSearchStationFinder(sc *searchconnector.TNSearchConnector) *tnSearchStationFinder {
+// New creates finder based on telenav search web service
+func New(sc *searchconnector.TNSearchConnector) *tnSearchStationFinder {
 	return &tnSearchStationFinder{
 		sc: sc,
 	}

--- a/integration/service/oasis/stationfinder/cloudfinder/tnsearch_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/tnsearch_station_finder.go
@@ -7,28 +7,28 @@ import (
 	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
 )
 
-type tnSearchStationFinder struct {
+type cloudStationFinder struct {
 	sc *searchconnector.TNSearchConnector
 }
 
 // New creates finder based on telenav search web service
-func New(sc *searchconnector.TNSearchConnector) *tnSearchStationFinder {
-	return &tnSearchStationFinder{
+func New(sc *searchconnector.TNSearchConnector) *cloudStationFinder {
+	return &cloudStationFinder{
 		sc: sc,
 	}
 }
 
 // NewOrigStationFinder creates finder to search for nearby charge stations near orig based on telenav search
-func (finder *tnSearchStationFinder) NewOrigStationFinder(oasisReq *oasis.Request) stationfindertype.NearbyStationsIterator {
+func (finder *cloudStationFinder) NewOrigStationFinder(oasisReq *oasis.Request) stationfindertype.NearbyStationsIterator {
 	return NewOrigStationFinder(finder.sc, oasisReq)
 }
 
 // NewDestStationFinder creates finder to search for nearby charge stations near destination based on telenav search
-func (finder *tnSearchStationFinder) NewDestStationFinder(oasisReq *oasis.Request) stationfindertype.NearbyStationsIterator {
+func (finder *cloudStationFinder) NewDestStationFinder(oasisReq *oasis.Request) stationfindertype.NearbyStationsIterator {
 	return NewDestStationFinder(finder.sc, oasisReq)
 }
 
 // NewLowEnergyLocationStationFinder creates finder to search for nearby charge stations when energy is low based on telenav search
-func (finder *tnSearchStationFinder) NewLowEnergyLocationStationFinder(location *nav.Location) stationfindertype.NearbyStationsIterator {
+func (finder *cloudStationFinder) NewLowEnergyLocationStationFinder(location *nav.Location) stationfindertype.NearbyStationsIterator {
 	return NewLowEnergyLocationStationFinder(finder.sc, location)
 }

--- a/integration/service/oasis/stationfinder/doc.go
+++ b/integration/service/oasis/stationfinder/doc.go
@@ -3,12 +3,12 @@
 Package stationfinder provide functionality to find nearby charge stations and
 related algorithm.
 It's find functionality could be achieved by:
-- TNSearchFinder, which is implemented by Telenav's search web service.
+- cloudfinder, which is implemented by Telenav's search web service.
   + The data source is from professional data
   + Based on Lucence and hilbert value
   + Could potentially supports dynamic information
 
-- LocalIndexerFinder
+- localfinder, which is implemented by spatial index built on local
   + Support any kind of data sources as long as following format defined in https://github.com/Telenav/osrm-backend/issues/237#issue-585201041
   + For Telenav usage, uses the same source with Telenav search service
   + Spatial index is build based on google s2

--- a/integration/service/oasis/stationfinder/interface.go
+++ b/integration/service/oasis/stationfinder/interface.go
@@ -23,7 +23,7 @@ type StationFinder interface {
 type Algorithm interface {
 	// FindOverlapBetweenStations finds overlap charge stations based on two iterator
 	FindOverlapBetweenStations(iterF stationfindertype.NearbyStationsIterator,
-		iterS stationfindertype.NearbyStationsIterator) []stationfindertype.ChargeStationInfo
+		iterS stationfindertype.NearbyStationsIterator) []*stationfindertype.ChargeStationInfo
 
 	// CalcWeightBetweenChargeStationsPair accepts two iterators and calculates weights between each pair of iterators
 	CalcWeightBetweenChargeStationsPair(from stationfindertype.NearbyStationsIterator,

--- a/integration/service/oasis/stationfinder/localfinder/basic_local_finder.go
+++ b/integration/service/oasis/stationfinder/localfinder/basic_local_finder.go
@@ -1,0 +1,83 @@
+package localfinder
+
+import (
+	"strconv"
+
+	"github.com/Telenav/osrm-backend/integration/pkg/api/nav"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/spatialindexer"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
+	"github.com/golang/glog"
+)
+
+const defaultIteratorCount = 5
+const defaultChargeStaionChannelSize = 500
+
+type basicLocalFinder struct {
+	localFinder spatialindexer.Finder
+	placesInfo  []*spatialindexer.PointInfo
+	requests    chan chan *stationfindertype.ChargeStationInfo
+	stop        chan bool
+}
+
+func newBasicLocalFinder(localFinder spatialindexer.Finder) *basicLocalFinder {
+	bf := &basicLocalFinder{
+		localFinder: localFinder,
+		requests:    make(chan chan *stationfindertype.ChargeStationInfo, defaultIteratorCount),
+		stop:        make(chan bool),
+	}
+	go bf.serveRequest()
+	return bf
+}
+
+func (bf *basicLocalFinder) getNearbyChargeStations(center spatialindexer.Location, radius float64) {
+	bf.placesInfo = bf.localFinder.FindNearByPointIDs(center, radius, spatialindexer.UnlimitedCount)
+}
+
+func (bf *basicLocalFinder) serveRequest() {
+	stopServe := false
+
+	for bf.requests != nil && bf.stop != nil {
+		select {
+		case c := <-bf.requests:
+			for _, placeInfo := range bf.placesInfo {
+				c <- &stationfindertype.ChargeStationInfo{
+					ID: strconv.FormatInt((int64)(placeInfo.ID), 10),
+					Location: nav.Location{
+						Lat: placeInfo.Location.Lat,
+						Lon: placeInfo.Location.Lon,
+					},
+				}
+			}
+			close(c)
+
+			if stopServe == true && len(bf.requests) == 0 {
+				close(bf.requests)
+				bf.requests = nil
+			}
+
+		case stopServe = <-bf.stop:
+			bf.stop = nil
+		}
+	}
+
+}
+
+// IterateNearbyStations returns channel contains near by stations
+func (bf *basicLocalFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
+	c := make(chan *stationfindertype.ChargeStationInfo, defaultChargeStaionChannelSize)
+	if bf.requests != nil {
+		bf.requests <- c
+	} else {
+		glog.Warning("Call iterator on Stopped Finder, please check your logic.\n")
+		close(c)
+	}
+
+	return c
+}
+
+// Stop stops functionality of finder
+func (bf *basicLocalFinder) Stop() {
+	if bf.stop != nil {
+		bf.stop <- true
+	}
+}

--- a/integration/service/oasis/stationfinder/localfinder/basic_local_finder_test.go
+++ b/integration/service/oasis/stationfinder/localfinder/basic_local_finder_test.go
@@ -1,0 +1,49 @@
+package localfinder
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Telenav/osrm-backend/integration/service/oasis/spatialindexer"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
+)
+
+func TestSingleIterator4BasicLocalFinder(t *testing.T) {
+	localFinder := newBasicLocalFinder(nil)
+	defer localFinder.Stop()
+
+	mockFinder := spatialindexer.MockFinder{}
+	localFinder.placesInfo = mockFinder.FindNearByPointIDs(spatialindexer.Location{}, 0, 0)
+
+	iterC := localFinder.IterateNearbyStations()
+	actual := make([]*stationfindertype.ChargeStationInfo, 0, len(stationfindertype.MockChargeStationInfo1))
+	for item := range iterC {
+		actual = append(actual, item)
+	}
+
+	if !reflect.DeepEqual(actual, stationfindertype.MockChargeStationInfo1) {
+		t.Errorf("Incorrect iterator result expect \n%#v\n but got \n%#v\n", stationfindertype.MockChargeStationInfo1, actual)
+	}
+
+}
+
+func TestMultipleIterator4BasicLocalFinder(t *testing.T) {
+	localFinder := newBasicLocalFinder(nil)
+	defer localFinder.Stop()
+
+	mockFinder := spatialindexer.MockFinder{}
+	localFinder.placesInfo = mockFinder.FindNearByPointIDs(spatialindexer.Location{}, 0, 0)
+
+	for i := 0; i < 3; i++ {
+		iterC := localFinder.IterateNearbyStations()
+		actual := make([]*stationfindertype.ChargeStationInfo, 0, len(stationfindertype.MockChargeStationInfo1))
+		for item := range iterC {
+			actual = append(actual, item)
+		}
+
+		if !reflect.DeepEqual(actual, stationfindertype.MockChargeStationInfo1) {
+			t.Errorf("Incorrect iterator result expect \n%#v\n but got \n%#v\n", stationfindertype.MockChargeStationInfo1, actual)
+		}
+	}
+
+}

--- a/integration/service/oasis/stationfinder/localfinder/dest_station_local_finder.go
+++ b/integration/service/oasis/stationfinder/localfinder/dest_station_local_finder.go
@@ -32,10 +32,12 @@ func newDestStationFinder(localFinder spatialindexer.Finder, oasisReq *oasis.Req
 	return obj
 }
 
+// NearbyStationsIterator provides channel which contains near by station information for dest
 func (localFinder *destStationLocalFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
 	return localFinder.basicFinder.IterateNearbyStations()
 }
 
+// Stop stops functionality of finder
 func (localFinder *destStationLocalFinder) Stop() {
 	localFinder.basicFinder.Stop()
 }

--- a/integration/service/oasis/stationfinder/localfinder/dest_station_local_finder.go
+++ b/integration/service/oasis/stationfinder/localfinder/dest_station_local_finder.go
@@ -1,0 +1,41 @@
+package localfinder
+
+import (
+	"github.com/Telenav/osrm-backend/integration/pkg/api/oasis"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/spatialindexer"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
+	"github.com/golang/glog"
+)
+
+type destStationLocalFinder struct {
+	basicFinder *basicLocalFinder
+}
+
+func newDestStationFinder(localFinder spatialindexer.Finder, oasisReq *oasis.Request) *destStationLocalFinder {
+	if len(oasisReq.Coordinates) != 2 {
+		glog.Errorf("Try to create newOrigStationFinder use incorrect oasis request, len(oasisReq.Coordinates) should be 2 but got %d.\n", len(oasisReq.Coordinates))
+		return nil
+	}
+	if oasisReq.MaxRange <= oasisReq.SafeLevel {
+		glog.Errorf("Try to create newOrigStationFinder use incorrect oasis request, SafeLevel should be smaller than MaxRange.\n")
+		return nil
+	}
+
+	obj := &destStationLocalFinder{
+		basicFinder: newBasicLocalFinder(localFinder),
+	}
+	obj.basicFinder.getNearbyChargeStations(spatialindexer.Location{
+		Lat: oasisReq.Coordinates[1].Lat,
+		Lon: oasisReq.Coordinates[1].Lon},
+		oasisReq.MaxRange-oasisReq.SafeLevel)
+
+	return obj
+}
+
+func (localFinder *destStationLocalFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
+	return localFinder.basicFinder.IterateNearbyStations()
+}
+
+func (localFinder *destStationLocalFinder) Stop() {
+	localFinder.basicFinder.Stop()
+}

--- a/integration/service/oasis/stationfinder/localfinder/doc.go
+++ b/integration/service/oasis/stationfinder/localfinder/doc.go
@@ -1,0 +1,4 @@
+/*
+Package localfinder provides spatial query based on prebuild spatial index which is recorded on local.
+*/
+package localfinder

--- a/integration/service/oasis/stationfinder/localfinder/local_station_finder.go
+++ b/integration/service/oasis/stationfinder/localfinder/local_station_finder.go
@@ -1,0 +1,34 @@
+package localfinder
+
+import (
+	"github.com/Telenav/osrm-backend/integration/pkg/api/nav"
+	"github.com/Telenav/osrm-backend/integration/pkg/api/oasis"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/spatialindexer"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
+)
+
+type localStationFinder struct {
+	localFinder spatialindexer.Finder
+}
+
+// New creates finder based on telenav search web service
+func New(localFinder spatialindexer.Finder) *localStationFinder {
+	return &localStationFinder{
+		localFinder: localFinder,
+	}
+}
+
+// NewOrigStationFinder creates finder to search for nearby charge stations near orig based on telenav search
+func (finder *localStationFinder) NewOrigStationFinder(oasisReq *oasis.Request) stationfindertype.NearbyStationsIterator {
+	return newOrigStationFinder(finder.localFinder, oasisReq)
+}
+
+// NewDestStationFinder creates finder to search for nearby charge stations near destination based on telenav search
+func (finder *localStationFinder) NewDestStationFinder(oasisReq *oasis.Request) stationfindertype.NearbyStationsIterator {
+	return newDestStationFinder(finder.localFinder, oasisReq)
+}
+
+// NewLowEnergyLocationStationFinder creates finder to search for nearby charge stations when energy is low based on telenav search
+func (finder *localStationFinder) NewLowEnergyLocationStationFinder(location *nav.Location) stationfindertype.NearbyStationsIterator {
+	return newLowEnergyLocationLocalFinder(finder.localFinder, location)
+}

--- a/integration/service/oasis/stationfinder/localfinder/low_energy_location_local_finder.go
+++ b/integration/service/oasis/stationfinder/localfinder/low_energy_location_local_finder.go
@@ -3,9 +3,11 @@ package localfinder
 import (
 	"github.com/Telenav/osrm-backend/integration/pkg/api/nav"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/spatialindexer"
-	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/cloudfinder"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
 )
+
+// lowEnergySearchRadius defines search radius for low energy location
+const lowEnergySearchRadius = 80000
 
 type lowEnergyLocationLocalFinder struct {
 	basicFinder *basicLocalFinder
@@ -19,16 +21,18 @@ func newLowEnergyLocationLocalFinder(localFinder spatialindexer.Finder, location
 	obj.basicFinder.getNearbyChargeStations(spatialindexer.Location{
 		Lat: location.Lat,
 		Lon: location.Lon},
-		cloudfinder.LowEnergyLocationCandidateNumber)
+		lowEnergySearchRadius)
 
 	return obj
 
 }
 
+// // NearbyStationsIterator provides channel which contains near by station information for low energy point
 func (localFinder *lowEnergyLocationLocalFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
 	return localFinder.basicFinder.IterateNearbyStations()
 }
 
+// Stop stops functionality of finder
 func (localFinder *lowEnergyLocationLocalFinder) Stop() {
 	localFinder.basicFinder.Stop()
 }

--- a/integration/service/oasis/stationfinder/localfinder/low_energy_location_local_finder.go
+++ b/integration/service/oasis/stationfinder/localfinder/low_energy_location_local_finder.go
@@ -1,0 +1,34 @@
+package localfinder
+
+import (
+	"github.com/Telenav/osrm-backend/integration/pkg/api/nav"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/spatialindexer"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/cloudfinder"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
+)
+
+type lowEnergyLocationLocalFinder struct {
+	basicFinder *basicLocalFinder
+}
+
+func newLowEnergyLocationLocalFinder(localFinder spatialindexer.Finder, location *nav.Location) *lowEnergyLocationLocalFinder {
+
+	obj := &lowEnergyLocationLocalFinder{
+		basicFinder: newBasicLocalFinder(localFinder),
+	}
+	obj.basicFinder.getNearbyChargeStations(spatialindexer.Location{
+		Lat: location.Lat,
+		Lon: location.Lon},
+		cloudfinder.LowEnergyLocationCandidateNumber)
+
+	return obj
+
+}
+
+func (localFinder *lowEnergyLocationLocalFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
+	return localFinder.basicFinder.IterateNearbyStations()
+}
+
+func (localFinder *lowEnergyLocationLocalFinder) Stop() {
+	localFinder.basicFinder.Stop()
+}

--- a/integration/service/oasis/stationfinder/localfinder/orig_station_local_finder.go
+++ b/integration/service/oasis/stationfinder/localfinder/orig_station_local_finder.go
@@ -1,0 +1,36 @@
+package localfinder
+
+import (
+	"github.com/Telenav/osrm-backend/integration/pkg/api/oasis"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/spatialindexer"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
+	"github.com/golang/glog"
+)
+
+type origStationLocalFinder struct {
+	basicFinder *basicLocalFinder
+}
+
+func newOrigStationFinder(localFinder spatialindexer.Finder, oasisReq *oasis.Request) *origStationLocalFinder {
+	if len(oasisReq.Coordinates) != 2 {
+		glog.Errorf("Incorrect oasis request pass into newOrigStationFinder, len(oasisReq.Coordinates) should be 2 but got %d.\n", len(oasisReq.Coordinates))
+	}
+
+	obj := &origStationLocalFinder{
+		basicFinder: newBasicLocalFinder(localFinder),
+	}
+	obj.basicFinder.getNearbyChargeStations(spatialindexer.Location{
+		Lat: oasisReq.Coordinates[0].Lat,
+		Lon: oasisReq.Coordinates[0].Lon},
+		oasisReq.CurrRange)
+
+	return obj
+}
+
+func (localFinder *origStationLocalFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
+	return localFinder.basicFinder.IterateNearbyStations()
+}
+
+func (localFinder *origStationLocalFinder) Stop() {
+	localFinder.basicFinder.Stop()
+}

--- a/integration/service/oasis/stationfinder/localfinder/orig_station_local_finder.go
+++ b/integration/service/oasis/stationfinder/localfinder/orig_station_local_finder.go
@@ -27,6 +27,7 @@ func newOrigStationFinder(localFinder spatialindexer.Finder, oasisReq *oasis.Req
 	return obj
 }
 
+// NearbyStationsIterator provides channel which contains near by station information for orig
 func (localFinder *origStationLocalFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
 	return localFinder.basicFinder.IterateNearbyStations()
 }

--- a/integration/service/oasis/stationfinder/station_finder_factory.go
+++ b/integration/service/oasis/stationfinder/station_finder_factory.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Telenav/osrm-backend/integration/service/oasis/searchconnector"
-	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/tnsearchfinder"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/cloudfinder"
 	"github.com/golang/glog"
 )
 
@@ -25,7 +25,7 @@ func CreateStationsFinder(finderType, searchEndpoint, apiKey, apiSignature strin
 	switch finderType {
 	case TNSearchFinder:
 		searchFinder := searchconnector.NewTNSearchConnector(searchEndpoint, apiKey, apiSignature)
-		return tnsearchfinder.NewTnSearchStationFinder(searchFinder), nil
+		return cloudfinder.New(searchFinder), nil
 	}
 	return nil, nil
 }

--- a/integration/service/oasis/stationfinder/stationfinderalg/dest_iterator.go
+++ b/integration/service/oasis/stationfinder/stationfinderalg/dest_iterator.go
@@ -17,8 +17,8 @@ func NewDestIter(location *nav.Location) *destIterator {
 	}
 }
 
-func (di *destIterator) IterateNearbyStations() <-chan stationfindertype.ChargeStationInfo {
-	c := make(chan stationfindertype.ChargeStationInfo, 1)
+func (di *destIterator) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
+	c := make(chan *stationfindertype.ChargeStationInfo, 1)
 
 	go func() {
 		defer close(c)
@@ -26,7 +26,7 @@ func (di *destIterator) IterateNearbyStations() <-chan stationfindertype.ChargeS
 			ID:       stationfindertype.DestLocationID,
 			Location: *di.location,
 		}
-		c <- station
+		c <- &station
 	}()
 
 	return c

--- a/integration/service/oasis/stationfinder/stationfinderalg/orig_iterator.go
+++ b/integration/service/oasis/stationfinder/stationfinderalg/orig_iterator.go
@@ -17,8 +17,8 @@ func NewOrigIter(location *nav.Location) *origIterator {
 	}
 }
 
-func (oi *origIterator) IterateNearbyStations() <-chan stationfindertype.ChargeStationInfo {
-	c := make(chan stationfindertype.ChargeStationInfo, 1)
+func (oi *origIterator) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
+	c := make(chan *stationfindertype.ChargeStationInfo, 1)
 
 	go func() {
 		defer close(c)
@@ -26,7 +26,7 @@ func (oi *origIterator) IterateNearbyStations() <-chan stationfindertype.ChargeS
 			ID:       stationfindertype.OrigLocationID,
 			Location: *oi.location,
 		}
-		c <- station
+		c <- &station
 	}()
 
 	return c

--- a/integration/service/oasis/stationfinder/stationfinderalg/stations_iterator_alg.go
+++ b/integration/service/oasis/stationfinder/stationfinderalg/stations_iterator_alg.go
@@ -14,8 +14,8 @@ import (
 )
 
 // FindOverlapBetweenStations finds overlap charge stations based on two iterator
-func FindOverlapBetweenStations(iterF stationfindertype.NearbyStationsIterator, iterS stationfindertype.NearbyStationsIterator) []stationfindertype.ChargeStationInfo {
-	var overlap []stationfindertype.ChargeStationInfo
+func FindOverlapBetweenStations(iterF stationfindertype.NearbyStationsIterator, iterS stationfindertype.NearbyStationsIterator) []*stationfindertype.ChargeStationInfo {
+	var overlap []*stationfindertype.ChargeStationInfo
 	dict := buildChargeStationInfoDict(iterF)
 	c := iterS.IterateNearbyStations()
 	for item := range c {

--- a/integration/service/oasis/stationfinder/stationfinderalg/stations_iterator_alg_test.go
+++ b/integration/service/oasis/stationfinder/stationfinderalg/stations_iterator_alg_test.go
@@ -34,15 +34,15 @@ func TestBuildChargeStationInfoDict1(t *testing.T) {
 	}
 }
 
-var overlapChargeStationInfo1 []stationfindertype.ChargeStationInfo = []stationfindertype.ChargeStationInfo{
-	stationfindertype.ChargeStationInfo{
+var overlapChargeStationInfo1 = []*stationfindertype.ChargeStationInfo{
+	{
 		ID: "station1",
 		Location: nav.Location{
 			Lat: 32.333,
 			Lon: 122.333,
 		},
 	},
-	stationfindertype.ChargeStationInfo{
+	{
 		ID: "station2",
 		Location: nav.Location{
 			Lat: -32.333,
@@ -282,7 +282,7 @@ func TestCalculateWeightBetweenNeighbors(t *testing.T) {
 	oc := osrmconnector.NewOSRMConnector(ts.URL)
 
 	// create finder based on fake TNSearchService
-	finder, err := stationfinder.CreateStationsFinder(stationfinder.TNSearchFinder, ts.URL, "apikey", "apisignature")
+	finder, err := stationfinder.CreateStationsFinder(stationfinder.TNSearchFinder, ts.URL, "apikey", "apisignature", "")
 	if err != nil {
 		t.Errorf("Failed to create station finder during TestCalculateWeightBetweenNeighbors with error = %+v.\n", err)
 	}

--- a/integration/service/oasis/stationfinder/stationfinderalg/stations_iterator_alg_test.go
+++ b/integration/service/oasis/stationfinder/stationfinderalg/stations_iterator_alg_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/Telenav/osrm-backend/integration/pkg/api/search/nearbychargestation"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/osrmconnector"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/cloudfinder"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
-	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/tnsearchfinder"
 	"github.com/Telenav/osrm-backend/integration/util"
 )
 
@@ -27,7 +27,7 @@ var mockDict1 map[string]bool = map[string]bool{
 }
 
 func TestBuildChargeStationInfoDict1(t *testing.T) {
-	sf := tnsearchfinder.CreateMockOrigStationFinder1()
+	sf := cloudfinder.CreateMockOrigStationFinder1()
 	m := buildChargeStationInfoDict(sf)
 	if !reflect.DeepEqual(m, mockDict1) {
 		t.Errorf("expect %v but got %v", mockDict1, m)
@@ -52,8 +52,8 @@ var overlapChargeStationInfo1 []stationfindertype.ChargeStationInfo = []stationf
 }
 
 func TestFindOverlapBetweenStations1(t *testing.T) {
-	sf1 := tnsearchfinder.CreateMockOrigStationFinder2()
-	sf2 := tnsearchfinder.CreateMockDestStationFinder1()
+	sf1 := cloudfinder.CreateMockOrigStationFinder2()
+	sf2 := cloudfinder.CreateMockDestStationFinder1()
 	r := FindOverlapBetweenStations(sf1, sf2)
 
 	if !reflect.DeepEqual(r, overlapChargeStationInfo1) {
@@ -79,9 +79,9 @@ func (ft *fakeTableResponse) Request4Table(r *table.Request) <-chan osrmconnecto
 
 func TestCalcNeighborInfoPair(t *testing.T) {
 	// from: station1, station2, station3, station4
-	sf1 := tnsearchfinder.CreateMockOrigStationFinder1()
+	sf1 := cloudfinder.CreateMockOrigStationFinder1()
 	// to: station6, station7
-	sf2 := tnsearchfinder.CreateMockOrigStationFinder3()
+	sf2 := cloudfinder.CreateMockOrigStationFinder3()
 
 	table := &fakeTableResponse{}
 	r, err := CalcWeightBetweenChargeStationsPair(sf1, sf2, table)

--- a/integration/service/oasis/stationfinder/stationfindertype/type.go
+++ b/integration/service/oasis/stationfinder/stationfindertype/type.go
@@ -5,7 +5,7 @@ import "github.com/Telenav/osrm-backend/integration/pkg/api/nav"
 // NearbyStationsIterator provide interator for near by stations
 type NearbyStationsIterator interface {
 	// IterateNearbyStations returns a channel which contains near by charge station under certain conditions
-	IterateNearbyStations() <-chan ChargeStationInfo
+	IterateNearbyStations() <-chan *ChargeStationInfo
 }
 
 // ChargeStationInfo defines charge station information

--- a/integration/service/oasis/stationfinder/stationfindertype/type_mock.go
+++ b/integration/service/oasis/stationfinder/stationfindertype/type_mock.go
@@ -1,0 +1,92 @@
+package stationfindertype
+
+import (
+	"strconv"
+
+	"github.com/Telenav/osrm-backend/integration/pkg/api/nav"
+	"github.com/Telenav/osrm-backend/integration/service/oasis/spatialindexer"
+)
+
+// MockChargeStationInfo1 mocks array of *ChargeStationInfo which is compatible with spatialindexer.MockPlaceInfo1
+var MockChargeStationInfo1 = []*ChargeStationInfo{
+	{
+		ID: strconv.FormatInt((int64)(spatialindexer.MockPlaceInfo1[0].ID), 10),
+		Location: nav.Location{
+			Lat: spatialindexer.MockPlaceInfo1[0].Location.Lat,
+			Lon: spatialindexer.MockPlaceInfo1[0].Location.Lon,
+		},
+		err: nil,
+	},
+	{
+		ID: strconv.FormatInt((int64)(spatialindexer.MockPlaceInfo1[1].ID), 10),
+		Location: nav.Location{
+			Lat: spatialindexer.MockPlaceInfo1[1].Location.Lat,
+			Lon: spatialindexer.MockPlaceInfo1[1].Location.Lon,
+		},
+		err: nil,
+	},
+	{
+		ID: strconv.FormatInt((int64)(spatialindexer.MockPlaceInfo1[2].ID), 10),
+		Location: nav.Location{
+			Lat: spatialindexer.MockPlaceInfo1[2].Location.Lat,
+			Lon: spatialindexer.MockPlaceInfo1[2].Location.Lon,
+		},
+		err: nil,
+	},
+	{
+		ID: strconv.FormatInt((int64)(spatialindexer.MockPlaceInfo1[3].ID), 10),
+		Location: nav.Location{
+			Lat: spatialindexer.MockPlaceInfo1[3].Location.Lat,
+			Lon: spatialindexer.MockPlaceInfo1[3].Location.Lon,
+		},
+		err: nil,
+	},
+	{
+		ID: strconv.FormatInt((int64)(spatialindexer.MockPlaceInfo1[4].ID), 10),
+		Location: nav.Location{
+			Lat: spatialindexer.MockPlaceInfo1[4].Location.Lat,
+			Lon: spatialindexer.MockPlaceInfo1[4].Location.Lon,
+		},
+		err: nil,
+	},
+	{
+		ID: strconv.FormatInt((int64)(spatialindexer.MockPlaceInfo1[5].ID), 10),
+		Location: nav.Location{
+			Lat: spatialindexer.MockPlaceInfo1[5].Location.Lat,
+			Lon: spatialindexer.MockPlaceInfo1[5].Location.Lon,
+		},
+		err: nil,
+	},
+	{
+		ID: strconv.FormatInt((int64)(spatialindexer.MockPlaceInfo1[6].ID), 10),
+		Location: nav.Location{
+			Lat: spatialindexer.MockPlaceInfo1[6].Location.Lat,
+			Lon: spatialindexer.MockPlaceInfo1[6].Location.Lon,
+		},
+		err: nil,
+	},
+	{
+		ID: strconv.FormatInt((int64)(spatialindexer.MockPlaceInfo1[7].ID), 10),
+		Location: nav.Location{
+			Lat: spatialindexer.MockPlaceInfo1[7].Location.Lat,
+			Lon: spatialindexer.MockPlaceInfo1[7].Location.Lon,
+		},
+		err: nil,
+	},
+	{
+		ID: strconv.FormatInt((int64)(spatialindexer.MockPlaceInfo1[8].ID), 10),
+		Location: nav.Location{
+			Lat: spatialindexer.MockPlaceInfo1[8].Location.Lat,
+			Lon: spatialindexer.MockPlaceInfo1[8].Location.Lon,
+		},
+		err: nil,
+	},
+	{
+		ID: strconv.FormatInt((int64)(spatialindexer.MockPlaceInfo1[9].ID), 10),
+		Location: nav.Location{
+			Lat: spatialindexer.MockPlaceInfo1[9].Location.Lat,
+			Lon: spatialindexer.MockPlaceInfo1[9].Location.Lon,
+		},
+		err: nil,
+	},
+}


### PR DESCRIPTION
# Issue
https://github.com/Telenav/osrm-backend/issues/240

### Major changes
- change the name of tnsearchfinder to cloudfinder
- implement local station finder based on google:s2 indexer

### Minor changes
- change name of NewTnSearchStationFinder to New
- add protection code in go func() in unit test of orig_station_finder_test.go
- change return value of IterateNearbyStations() from `<-chan stationfindertype.ChargeStationInfo` to `<-chan *stationfindertype.ChargeStationInfo`, original strategy is easy to create bugs while convert channel result into pointers https://play.golang.org/p/gWgJpEOSuj6

### To do
- Change `spatialindexer.PointInfo` to `spatialindexer.PlaceInfo`
- Replace `spatialindexer.Location` to `nav.Location`
- Integrate `Stop` functionality into Station Finder's algorithms

## Tasklist

 - [ ] update relevant code
 - [ ] add tests 
 - [ ] review

