### PR TITLE
refactor: use `struct embedding` to avoid interface forwarding

### DIFF
--- a/integration/cmd/oasis/flags.go
+++ b/integration/cmd/oasis/flags.go
@@ -17,7 +17,7 @@ var flags struct {
 func init() {
 	flag.IntVar(&flags.listenPort, "p", 8090, "Listen port.")
 	flag.StringVar(&flags.osrmBackendEndpoint, "osrm", "", "OSRM-backend endpoint")
-	flag.StringVar(&flags.finderType, "finder", "", "Specify search finder to search for nearby charge stations for given location, use TNSearchFinder or LocalIndexerFinder")
+	flag.StringVar(&flags.finderType, "finder", "", "Specify search finder to search for nearby charge stations for given location, use CloudFinder or LocalFinder")
 	flag.StringVar(&flags.tnSearchEndpoint, "search", "", "TN-Search-backend endpoint")
 	flag.StringVar(&flags.tnSearchAPIKey, "searchApiKey", "", "API key for TN-Search-backend")
 	flag.StringVar(&flags.tnSearchAPISignature, "searchApiSignature", "", "API Signature for TN-Search-backend")

--- a/integration/service/oasis/stationfinder/cloudfinder/cloud_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/cloud_station_finder.go
@@ -20,15 +20,15 @@ func New(sc *searchconnector.TNSearchConnector) *cloudStationFinder {
 
 // NewOrigStationFinder creates finder to search for nearby charge stations near orig based on telenav search
 func (finder *cloudStationFinder) NewOrigStationFinder(oasisReq *oasis.Request) stationfindertype.NearbyStationsIterator {
-	return NewOrigStationFinder(finder.sc, oasisReq)
+	return newOrigStationFinder(finder.sc, oasisReq)
 }
 
 // NewDestStationFinder creates finder to search for nearby charge stations near destination based on telenav search
 func (finder *cloudStationFinder) NewDestStationFinder(oasisReq *oasis.Request) stationfindertype.NearbyStationsIterator {
-	return NewDestStationFinder(finder.sc, oasisReq)
+	return newDestStationFinder(finder.sc, oasisReq)
 }
 
 // NewLowEnergyLocationStationFinder creates finder to search for nearby charge stations when energy is low based on telenav search
 func (finder *cloudStationFinder) NewLowEnergyLocationStationFinder(location *nav.Location) stationfindertype.NearbyStationsIterator {
-	return NewLowEnergyLocationStationFinder(finder.sc, location)
+	return newLowEnergyLocationStationFinder(finder.sc, location)
 }

--- a/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder.go
@@ -1,49 +1,35 @@
 package cloudfinder
 
 import (
-	"sync"
-
 	"github.com/Telenav/osrm-backend/integration/pkg/api/oasis"
-	"github.com/Telenav/osrm-backend/integration/pkg/api/search/nearbychargestation"
 	"github.com/Telenav/osrm-backend/integration/pkg/api/search/searchcoordinate"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/searchconnector"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/searchhelper"
-	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
 )
 
 //@todo: This number need to be adjusted based on charge station profile
 const destMaxSearchCandidateNumber = 999
 
 type destStationFinder struct {
-	tnSearchConnector *searchconnector.TNSearchConnector
-	oasisReq          *oasis.Request
-	searchResp        *nearbychargestation.Response
-	searchRespLock    *sync.RWMutex
-	bf                *basicFinder
+	oasisReq *oasis.Request
+	*basicFinder
 }
 
-func NewDestStationFinder(sc *searchconnector.TNSearchConnector, oasisReq *oasis.Request) *destStationFinder {
+func newDestStationFinder(sc *searchconnector.TNSearchConnector, oasisReq *oasis.Request) *destStationFinder {
 	obj := &destStationFinder{
-		oasisReq: oasisReq,
-		bf:       newBasicFinder(sc),
+		oasisReq,
+		newBasicFinder(sc),
 	}
 	obj.prepare()
 	return obj
 }
 
-func (sf *destStationFinder) prepare() {
+func (dFinder *destStationFinder) prepare() {
 	req, _ := searchhelper.GenerateSearchRequest(
 		searchcoordinate.Coordinate{
-			Lat: sf.oasisReq.Coordinates[1].Lat,
-			Lon: sf.oasisReq.Coordinates[1].Lon},
+			Lat: dFinder.oasisReq.Coordinates[1].Lat,
+			Lon: dFinder.oasisReq.Coordinates[1].Lon},
 		destMaxSearchCandidateNumber,
-		sf.oasisReq.MaxRange-sf.oasisReq.SafeLevel)
-	sf.bf.getNearbyChargeStations(req)
-
-	return
-}
-
-// NearbyStationsIterator provides channel which contains near by station information for dest
-func (sf *destStationFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
-	return sf.bf.IterateNearbyStations()
+		dFinder.oasisReq.MaxRange-dFinder.oasisReq.SafeLevel)
+	dFinder.getNearbyChargeStations(req)
 }

--- a/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder_mock.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder_mock.go
@@ -9,8 +9,8 @@ import (
 // CreateMockDestStationFinder1 creates mock dest station finder with nearbychargestation.MockSearchResponse1
 func CreateMockDestStationFinder1() *destStationFinder {
 	obj := &destStationFinder{
-		oasisReq: nil,
-		bf: &basicFinder{
+		nil,
+		&basicFinder{
 			tnSearchConnector: nil,
 			searchResp:        nearbychargestation.MockSearchResponse1,
 			searchRespLock:    &sync.RWMutex{},
@@ -22,8 +22,8 @@ func CreateMockDestStationFinder1() *destStationFinder {
 // CreateMockDestStationFinder2 creates mock dest station finder with nearbychargestation.MockSearchResponse2
 func createMockDestStationFinder2() *destStationFinder {
 	obj := &destStationFinder{
-		oasisReq: nil,
-		bf: &basicFinder{
+		nil,
+		&basicFinder{
 			tnSearchConnector: nil,
 			searchResp:        nearbychargestation.MockSearchResponse2,
 			searchRespLock:    &sync.RWMutex{},
@@ -35,8 +35,8 @@ func createMockDestStationFinder2() *destStationFinder {
 // CreateMockDestStationFinder3 creates mock dest station finder with nearbychargestation.MockSearchResponse3
 func createMockDestStationFinder3() *destStationFinder {
 	obj := &destStationFinder{
-		oasisReq: nil,
-		bf: &basicFinder{
+		nil,
+		&basicFinder{
 			tnSearchConnector: nil,
 			searchResp:        nearbychargestation.MockSearchResponse3,
 			searchRespLock:    &sync.RWMutex{},

--- a/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder_test.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/dest_station_finder_test.go
@@ -11,13 +11,12 @@ func TestDestStationFinderIterator(t *testing.T) {
 	sf := CreateMockDestStationFinder1()
 	c := sf.IterateNearbyStations()
 	var r []*stationfindertype.ChargeStationInfo
-	go func() {
-		for item := range c {
-			r = append(r, item)
-		}
 
-		if !reflect.DeepEqual(r, mockChargeStationInfo1) {
-			t.Errorf("expect %v but got %v", mockChargeStationInfo1, r)
-		}
-	}()
+	for item := range c {
+		r = append(r, item)
+	}
+
+	if !reflect.DeepEqual(r, mockChargeStationInfo1) {
+		t.Errorf("expect %#v but got %#v", mockChargeStationInfo1, r)
+	}
 }

--- a/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder.go
@@ -5,7 +5,6 @@ import (
 	"github.com/Telenav/osrm-backend/integration/pkg/api/search/searchcoordinate"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/searchconnector"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/searchhelper"
-	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
 )
 
 // LowEnergyLocationCandidateNumber indicates how much charge station to be searched for low energy point
@@ -13,30 +12,25 @@ const LowEnergyLocationCandidateNumber = 20
 
 type lowEnergyLocationStationFinder struct {
 	location *nav.Location
-	bf       *basicFinder
+	*basicFinder
 }
 
-func NewLowEnergyLocationStationFinder(sc *searchconnector.TNSearchConnector, location *nav.Location) *lowEnergyLocationStationFinder {
+func newLowEnergyLocationStationFinder(sc *searchconnector.TNSearchConnector, location *nav.Location) *lowEnergyLocationStationFinder {
 	obj := &lowEnergyLocationStationFinder{
-		location: location,
-		bf:       newBasicFinder(sc),
+		location,
+		newBasicFinder(sc),
 	}
 	obj.prepare()
 	return obj
 }
 
-func (sf *lowEnergyLocationStationFinder) prepare() {
+func (lFinder *lowEnergyLocationStationFinder) prepare() {
 	req, _ := searchhelper.GenerateSearchRequest(
 		searchcoordinate.Coordinate{
-			Lat: sf.location.Lat,
-			Lon: sf.location.Lon},
+			Lat: lFinder.location.Lat,
+			Lon: lFinder.location.Lon},
 		LowEnergyLocationCandidateNumber,
 		-1)
-	sf.bf.getNearbyChargeStations(req)
+	lFinder.getNearbyChargeStations(req)
 	return
-}
-
-// NearbyStationsIterator provides channel which contains near by station information for low energy location
-func (sf *lowEnergyLocationStationFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
-	return sf.bf.IterateNearbyStations()
 }

--- a/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder_mock.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder_mock.go
@@ -9,8 +9,8 @@ import (
 // createMockLowEnergyLocationStationFinder1 creates mock low energy location station finder with nearbychargestation.MockSearchResponse1
 func createMockLowEnergyLocationStationFinder1() *lowEnergyLocationStationFinder {
 	obj := &lowEnergyLocationStationFinder{
-		location: nil,
-		bf: &basicFinder{
+		nil,
+		&basicFinder{
 			tnSearchConnector: nil,
 
 			searchResp:     nearbychargestation.MockSearchResponse1,
@@ -23,8 +23,8 @@ func createMockLowEnergyLocationStationFinder1() *lowEnergyLocationStationFinder
 // createMockLowEnergyLocationStationFinder2 creates mock low energy location station finder with nearbychargestation.MockSearchResponse2
 func createMockLowEnergyLocationStationFinder2() *lowEnergyLocationStationFinder {
 	obj := &lowEnergyLocationStationFinder{
-		location: nil,
-		bf: &basicFinder{
+		nil,
+		&basicFinder{
 			tnSearchConnector: nil,
 			searchResp:        nearbychargestation.MockSearchResponse2,
 			searchRespLock:    &sync.RWMutex{},
@@ -36,8 +36,8 @@ func createMockLowEnergyLocationStationFinder2() *lowEnergyLocationStationFinder
 // createMockLowEnergyLocationStationFinder3 creates mock low energy location station finder with nearbychargestation.MockSearchResponse3
 func createMockLowEnergyLocationStationFinder3() *lowEnergyLocationStationFinder {
 	obj := &lowEnergyLocationStationFinder{
-		location: nil,
-		bf: &basicFinder{
+		nil,
+		&basicFinder{
 			tnSearchConnector: nil,
 			searchResp:        nearbychargestation.MockSearchResponse3,
 			searchRespLock:    &sync.RWMutex{},

--- a/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder_test.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/low_energy_location_station_finder_test.go
@@ -23,7 +23,7 @@ func TestLowEnergyLocationStationFinderIterator1(t *testing.T) {
 			r = append(r, item)
 		}
 		if !reflect.DeepEqual(r, mockChargeStationInfo1) {
-			t.Errorf("expect %v but got %v", mockChargeStationInfo1, r)
+			t.Errorf("expect %#v but got %#v", mockChargeStationInfo1, r)
 		}
 	}(&wg)
 	wg.Wait()
@@ -42,7 +42,7 @@ func TestLowEnergyLocationStationFinderIterator2(t *testing.T) {
 			r = append(r, item)
 		}
 		if !reflect.DeepEqual(r, mockChargeStationInfo2) {
-			t.Errorf("expect %v but got %v", mockChargeStationInfo2, r)
+			t.Errorf("expect %#v but got %#v", mockChargeStationInfo2, r)
 		}
 	}(&wg)
 	wg.Wait()
@@ -61,7 +61,7 @@ func TestLowEnergyLocationStationFinderIterator3(t *testing.T) {
 			r = append(r, item)
 		}
 		if !reflect.DeepEqual(r, mockChargeStationInfo3) {
-			t.Errorf("expect %v but got %v", mockChargeStationInfo3, r)
+			t.Errorf("expect %#v but got %#v", mockChargeStationInfo3, r)
 		}
 	}(&wg)
 	wg.Wait()

--- a/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder.go
@@ -5,7 +5,6 @@ import (
 	"github.com/Telenav/osrm-backend/integration/pkg/api/search/searchcoordinate"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/searchconnector"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/searchhelper"
-	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
 )
 
 //@todo: This number need to be adjusted based on charge station profile
@@ -13,31 +12,26 @@ const origMaxSearchCandidateNumber = 999
 
 type origStationFinder struct {
 	oasisReq *oasis.Request
-	bf       *basicFinder
+	*basicFinder
 }
 
-func NewOrigStationFinder(sc *searchconnector.TNSearchConnector, oasisReq *oasis.Request) *origStationFinder {
+func newOrigStationFinder(sc *searchconnector.TNSearchConnector, oasisReq *oasis.Request) *origStationFinder {
 	obj := &origStationFinder{
-		oasisReq: oasisReq,
-		bf:       newBasicFinder(sc),
+		oasisReq,
+		newBasicFinder(sc),
 	}
 	obj.prepare()
 	return obj
 }
 
-func (sf *origStationFinder) prepare() {
+func (oFinder *origStationFinder) prepare() {
 	req, _ := searchhelper.GenerateSearchRequest(
 		searchcoordinate.Coordinate{
-			Lat: sf.oasisReq.Coordinates[0].Lat,
-			Lon: sf.oasisReq.Coordinates[0].Lon},
+			Lat: oFinder.oasisReq.Coordinates[0].Lat,
+			Lon: oFinder.oasisReq.Coordinates[0].Lon},
 		origMaxSearchCandidateNumber,
-		sf.oasisReq.CurrRange)
+		oFinder.oasisReq.CurrRange)
 
-	sf.bf.getNearbyChargeStations(req)
+	oFinder.getNearbyChargeStations(req)
 	return
-}
-
-// NearbyStationsIterator provides channel which contains near by station information for orig
-func (sf *origStationFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
-	return sf.bf.IterateNearbyStations()
 }

--- a/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder_mock.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder_mock.go
@@ -9,8 +9,8 @@ import (
 // CreateMockOrigStationFinder1 creates mock orig station finder with nearbychargestation.MockSearchResponse1
 func CreateMockOrigStationFinder1() *origStationFinder {
 	obj := &origStationFinder{
-		oasisReq: nil,
-		bf: &basicFinder{
+		nil,
+		&basicFinder{
 			tnSearchConnector: nil,
 			searchResp:        nearbychargestation.MockSearchResponse1,
 			searchRespLock:    &sync.RWMutex{},
@@ -22,8 +22,8 @@ func CreateMockOrigStationFinder1() *origStationFinder {
 // CreateMockOrigStationFinder2 creates mock orig station finder with nearbychargestation.MockSearchResponse2
 func CreateMockOrigStationFinder2() *origStationFinder {
 	obj := &origStationFinder{
-		oasisReq: nil,
-		bf: &basicFinder{
+		nil,
+		&basicFinder{
 			tnSearchConnector: nil,
 			searchResp:        nearbychargestation.MockSearchResponse2,
 			searchRespLock:    &sync.RWMutex{},
@@ -35,8 +35,8 @@ func CreateMockOrigStationFinder2() *origStationFinder {
 // CreateMockOrigStationFinder3 creates mock orig station finder with nearbychargestation.MockSearchResponse3
 func CreateMockOrigStationFinder3() *origStationFinder {
 	obj := &origStationFinder{
-		oasisReq: nil,
-		bf: &basicFinder{
+		nil,
+		&basicFinder{
 			tnSearchConnector: nil,
 			searchResp:        nearbychargestation.MockSearchResponse3,
 			searchRespLock:    &sync.RWMutex{},

--- a/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder_test.go
+++ b/integration/service/oasis/stationfinder/cloudfinder/orig_station_finder_test.go
@@ -12,16 +12,12 @@ func TestOrigStationFinderIterator(t *testing.T) {
 	c := sf.IterateNearbyStations()
 	var r []*stationfindertype.ChargeStationInfo
 
-	isdoneC := make(chan bool)
-	go func() {
-		for item := range c {
-			r = append(r, item)
-		}
+	for item := range c {
+		r = append(r, item)
+	}
 
-		if !reflect.DeepEqual(r, mockChargeStationInfo1) {
-			t.Errorf("expect %v but got %v", mockChargeStationInfo1, r)
-		}
-		isdoneC <- true
-	}()
-	<-isdoneC
+	if !reflect.DeepEqual(r, mockChargeStationInfo1) {
+		t.Errorf("expect %#v but got %#v", mockChargeStationInfo1, r)
+	}
+
 }

--- a/integration/service/oasis/stationfinder/localfinder/dest_station_local_finder.go
+++ b/integration/service/oasis/stationfinder/localfinder/dest_station_local_finder.go
@@ -3,12 +3,11 @@ package localfinder
 import (
 	"github.com/Telenav/osrm-backend/integration/pkg/api/oasis"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/spatialindexer"
-	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
 	"github.com/golang/glog"
 )
 
 type destStationLocalFinder struct {
-	basicFinder *basicLocalFinder
+	*basicLocalFinder
 }
 
 func newDestStationFinder(localFinder spatialindexer.Finder, oasisReq *oasis.Request) *destStationLocalFinder {
@@ -22,22 +21,12 @@ func newDestStationFinder(localFinder spatialindexer.Finder, oasisReq *oasis.Req
 	}
 
 	obj := &destStationLocalFinder{
-		basicFinder: newBasicLocalFinder(localFinder),
+		newBasicLocalFinder(localFinder),
 	}
-	obj.basicFinder.getNearbyChargeStations(spatialindexer.Location{
+	obj.getNearbyChargeStations(spatialindexer.Location{
 		Lat: oasisReq.Coordinates[1].Lat,
 		Lon: oasisReq.Coordinates[1].Lon},
 		oasisReq.MaxRange-oasisReq.SafeLevel)
 
 	return obj
-}
-
-// NearbyStationsIterator provides channel which contains near by station information for dest
-func (localFinder *destStationLocalFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
-	return localFinder.basicFinder.IterateNearbyStations()
-}
-
-// Stop stops functionality of finder
-func (localFinder *destStationLocalFinder) Stop() {
-	localFinder.basicFinder.Stop()
 }

--- a/integration/service/oasis/stationfinder/localfinder/low_energy_location_local_finder.go
+++ b/integration/service/oasis/stationfinder/localfinder/low_energy_location_local_finder.go
@@ -3,36 +3,25 @@ package localfinder
 import (
 	"github.com/Telenav/osrm-backend/integration/pkg/api/nav"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/spatialindexer"
-	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
 )
 
 // lowEnergySearchRadius defines search radius for low energy location
 const lowEnergySearchRadius = 80000
 
 type lowEnergyLocationLocalFinder struct {
-	basicFinder *basicLocalFinder
+	*basicLocalFinder
 }
 
 func newLowEnergyLocationLocalFinder(localFinder spatialindexer.Finder, location *nav.Location) *lowEnergyLocationLocalFinder {
 
 	obj := &lowEnergyLocationLocalFinder{
-		basicFinder: newBasicLocalFinder(localFinder),
+		newBasicLocalFinder(localFinder),
 	}
-	obj.basicFinder.getNearbyChargeStations(spatialindexer.Location{
+	obj.getNearbyChargeStations(spatialindexer.Location{
 		Lat: location.Lat,
 		Lon: location.Lon},
 		lowEnergySearchRadius)
 
 	return obj
 
-}
-
-// // NearbyStationsIterator provides channel which contains near by station information for low energy point
-func (localFinder *lowEnergyLocationLocalFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
-	return localFinder.basicFinder.IterateNearbyStations()
-}
-
-// Stop stops functionality of finder
-func (localFinder *lowEnergyLocationLocalFinder) Stop() {
-	localFinder.basicFinder.Stop()
 }

--- a/integration/service/oasis/stationfinder/localfinder/orig_station_local_finder.go
+++ b/integration/service/oasis/stationfinder/localfinder/orig_station_local_finder.go
@@ -3,12 +3,11 @@ package localfinder
 import (
 	"github.com/Telenav/osrm-backend/integration/pkg/api/oasis"
 	"github.com/Telenav/osrm-backend/integration/service/oasis/spatialindexer"
-	"github.com/Telenav/osrm-backend/integration/service/oasis/stationfinder/stationfindertype"
 	"github.com/golang/glog"
 )
 
 type origStationLocalFinder struct {
-	basicFinder *basicLocalFinder
+	*basicLocalFinder
 }
 
 func newOrigStationFinder(localFinder spatialindexer.Finder, oasisReq *oasis.Request) *origStationLocalFinder {
@@ -17,21 +16,12 @@ func newOrigStationFinder(localFinder spatialindexer.Finder, oasisReq *oasis.Req
 	}
 
 	obj := &origStationLocalFinder{
-		basicFinder: newBasicLocalFinder(localFinder),
+		newBasicLocalFinder(localFinder),
 	}
-	obj.basicFinder.getNearbyChargeStations(spatialindexer.Location{
+	obj.getNearbyChargeStations(spatialindexer.Location{
 		Lat: oasisReq.Coordinates[0].Lat,
 		Lon: oasisReq.Coordinates[0].Lon},
 		oasisReq.CurrRange)
 
 	return obj
-}
-
-// NearbyStationsIterator provides channel which contains near by station information for orig
-func (localFinder *origStationLocalFinder) IterateNearbyStations() <-chan *stationfindertype.ChargeStationInfo {
-	return localFinder.basicFinder.IterateNearbyStations()
-}
-
-func (localFinder *origStationLocalFinder) Stop() {
-	localFinder.basicFinder.Stop()
 }

--- a/integration/service/oasis/stationfinder/station_finder_factory.go
+++ b/integration/service/oasis/stationfinder/station_finder_factory.go
@@ -10,11 +10,11 @@ import (
 )
 
 const (
-	// TNSearchFinder is powered by Telenav Search's web services.
-	TNSearchFinder = "TNSearchFinder"
+	// CloudFinder is powered by Telenav Search's web services.
+	CloudFinder = "CloudFinder"
 
-	// LocalIndexerFinder is supported by pre-processed spatial index(such as google:s2) which is recorded on local.
-	LocalIndexerFinder = "LocalIndexerFinder"
+	// LocalFinder is supported by pre-processed spatial index(such as google:s2) which is recorded on local.
+	LocalFinder = "LocalFinder"
 )
 
 // CreateStationsFinder creates finder which implements StationFinder interface
@@ -25,11 +25,11 @@ func CreateStationsFinder(finderType, searchEndpoint, apiKey, apiSignature, data
 
 	switch finderType {
 
-	case TNSearchFinder:
+	case CloudFinder:
 		searchFinder := searchconnector.NewTNSearchConnector(searchEndpoint, apiKey, apiSignature)
 		return cloudfinder.New(searchFinder), nil
 
-	case LocalIndexerFinder:
+	case LocalFinder:
 		localIndex := s2indexer.NewS2Indexer().Load(dataFolderPath)
 		if localIndex == nil {
 			err := fmt.Errorf("failed to load s2Indexer")
@@ -42,17 +42,17 @@ func CreateStationsFinder(finderType, searchEndpoint, apiKey, apiSignature, data
 
 // isValidStationFinderType returns false if finderType is unsupported, otherwise returns true
 func isValidStationFinderType(finderType string) bool {
-	return finderType == TNSearchFinder || finderType == LocalIndexerFinder
+	return finderType == CloudFinder || finderType == LocalFinder
 }
 
 func checkInput(finderType, searchEndpoint, apiKey, apiSignature, dataFolderPath string) error {
 	if !isValidStationFinderType(finderType) {
-		glog.Error("Try to create finder not implemented yet, can only choose TNSearchFinder or LocalFinder for now.\n")
+		glog.Error("Try to create finder not implemented yet, can only choose CloudFinder or LocalFinder for now.\n")
 		err := fmt.Errorf("invalid station finder type")
 		return err
 	}
 
-	if finderType == TNSearchFinder &&
+	if finderType == CloudFinder &&
 		(len(searchEndpoint) == 0 ||
 			len(apiKey) == 0 ||
 			len(apiSignature) == 0) {
@@ -60,7 +60,7 @@ func checkInput(finderType, searchEndpoint, apiKey, apiSignature, dataFolderPath
 		return err
 	}
 
-	if finderType == LocalIndexerFinder &&
+	if finderType == LocalFinder &&
 		len(dataFolderPath) == 0 {
 		err := fmt.Errorf("empty input for local index")
 		return err

--- a/integration/service/oasis/stationfinder/stationfinderalg/stations_iterator_alg_test.go
+++ b/integration/service/oasis/stationfinder/stationfinderalg/stations_iterator_alg_test.go
@@ -282,7 +282,7 @@ func TestCalculateWeightBetweenNeighbors(t *testing.T) {
 	oc := osrmconnector.NewOSRMConnector(ts.URL)
 
 	// create finder based on fake TNSearchService
-	finder, err := stationfinder.CreateStationsFinder(stationfinder.TNSearchFinder, ts.URL, "apikey", "apisignature", "")
+	finder, err := stationfinder.CreateStationsFinder(stationfinder.CloudFinder, ts.URL, "apikey", "apisignature", "")
 	if err != nil {
 		t.Errorf("Failed to create station finder during TestCalculateWeightBetweenNeighbors with error = %+v.\n", err)
 	}


### PR DESCRIPTION
issue: https://github.com/Telenav/osrm-backend/issues/279

- Use `struct embedding` to avoid function calling to interface implemented in base class
     + https://golang.org/doc/effective_go.html#embedding 
     + https://github.com/wangyoucao577/golang/tree/master/effective-go#embedding
     + https://play.golang.org/p/F6gmScefu5s
     + https://play.golang.org/p/xekNSmRLk9H
- Remove unnecessary `go-routine` in test
- Adjust name

## Tasklist

 - [ ] refactor
 - [ ] review
