### PR TITLE
Fix invalid nodes in annotations of response

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -13,6 +13,7 @@ Changes from v10.1.0
   - ADDED new cmd tool `nodes2way-builder` to generate the db from `wayid2nodeids.csv` or `wayid2nodeids.csv.snappy` [#274](https://github.com/Telenav/osrm-backend/pull/274)
   - ADDED new cmd tool `nodes2way-cli` to able to query ways from nodes [#274](https://github.com/Telenav/osrm-backend/pull/274)
   - CHANGED for internal refactoring, move `pkg/wayidsflag` to `util/idsflag` to extend its scope [#277](https://github.com/Telenav/osrm-backend/pull/277)
+  - CHANGED `annotation/nodes` from `Number` to `string` in `JSON` response to avoid conversion overflow **API CHANGE** []()    
 - Bugfix:    
 - Performance:    
   - CHANGED `nodes2way-builder` to improve the db building performance [#281](https://github.com/Telenav/osrm-backend/pull/281)

--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -13,7 +13,7 @@ Changes from v10.1.0
   - ADDED new cmd tool `nodes2way-builder` to generate the db from `wayid2nodeids.csv` or `wayid2nodeids.csv.snappy` [#274](https://github.com/Telenav/osrm-backend/pull/274)
   - ADDED new cmd tool `nodes2way-cli` to able to query ways from nodes [#274](https://github.com/Telenav/osrm-backend/pull/274)
   - CHANGED for internal refactoring, move `pkg/wayidsflag` to `util/idsflag` to extend its scope [#277](https://github.com/Telenav/osrm-backend/pull/277)
-  - CHANGED `annotation/nodes` from `Number` to `string` in `JSON` response to avoid conversion overflow **API CHANGE** []()    
+  - CHANGED `annotation/nodes` from `Number` to `string` in `JSON` response to avoid conversion overflow **API CHANGE** [#285](https://github.com/Telenav/osrm-backend/pull/285)    
 - Bugfix:    
 - Performance:    
   - CHANGED `nodes2way-builder` to improve the db building performance [#281](https://github.com/Telenav/osrm-backend/pull/281)

--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -13,7 +13,7 @@ Changes from v10.1.0
   - ADDED new cmd tool `nodes2way-builder` to generate the db from `wayid2nodeids.csv` or `wayid2nodeids.csv.snappy` [#274](https://github.com/Telenav/osrm-backend/pull/274)
   - ADDED new cmd tool `nodes2way-cli` to able to query ways from nodes [#274](https://github.com/Telenav/osrm-backend/pull/274)
   - CHANGED for internal refactoring, move `pkg/wayidsflag` to `util/idsflag` to extend its scope [#277](https://github.com/Telenav/osrm-backend/pull/277)
-  - CHANGED `annotation/nodes` from `Number` to `string` in `JSON` response to avoid conversion overflow **API CHANGE** [#285](https://github.com/Telenav/osrm-backend/pull/285)    
+  - CHANGED **HTTP API** `JSON` response `annotation/nodes` from `Number` to `string` to avoid conversion overflow [#285](https://github.com/Telenav/osrm-backend/pull/285)    
 - Bugfix:    
 - Performance:    
   - CHANGED `nodes2way-builder` to improve the db building performance [#281](https://github.com/Telenav/osrm-backend/pull/281)

--- a/docs/http.md
+++ b/docs/http.md
@@ -672,7 +672,7 @@ With `steps=false` and `annotations=true`:
     "duration": [15,15,40,15,15],
     "datasources": [1,0,0,0,1],
     "metadata": { "datasource_names": ["traffic","lua profile","lua profile","lua profile","traffic"] },
-    "nodes": [49772551,49772552,49786799,49786800,49786801,49786802],
+    "nodes": ["49772551","49772552","49786799","49786800","49786801","49786802"],
     "speed": [0.3, 0.3, 0.3, 0.3, 0.3]
   }
 }
@@ -701,7 +701,7 @@ Annotation of the whole route leg with fine-grained information about each segme
   "duration": [15,15,40,15,15],
   "datasources": [1,0,0,0,1],
   "metadata": { "datasource_names": ["traffic","lua profile","lua profile","lua profile","traffic"] },
-  "nodes": [49772551,49772552,49786799,49786800,49786801,49786802],
+  "nodes": ["49772551","49772552","49786799","49786800","49786801","49786802"],
   "weight": [15,15,40,15,15]
 }
 ```

--- a/include/engine/api/route_api.hpp
+++ b/include/engine/api/route_api.hpp
@@ -327,7 +327,7 @@ class RouteAPI : public BaseAPI
                     nodes.values.reserve(leg_geometry.osm_node_ids.size());
                     for (const auto node_id : leg_geometry.osm_node_ids)
                     {
-                        nodes.values.push_back(static_cast<std::uint64_t>(node_id));
+                        nodes.values.push_back(std::to_string(static_cast<std::uint64_t>(node_id)));
                     }
                     annotation.values["nodes"] = std::move(nodes);
                 }


### PR DESCRIPTION
# Issue

- Targeting issue: the issue will be CLOSED once the PR merged. If there is no issue that addresses the problem, please open a corresponding issue and link it here. Uses the [Closes keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close them automatically.     

Closes https://github.com/Telenav/osrm-backend/issues/276

- Any other related issue? Mention them here.    

## Description    
A summary description for what the PR achieves.           

- Use `string` instead of `Number` to store nodeid in JSON to avoid overflow since the `Number` is implemented by `double` that may insufficient for long `uint64_t`.        

NOTE that it's a short-term solution to unblock our post process at this moment. https://github.com/Telenav/osrm-backend/issues/276#issuecomment-615110149 and https://github.com/Telenav/osrm-backend/issues/276#issuecomment-615113474 discuss more on this.      
Once we have a better and right way to go, I'll revert this change and solve the problem by the right way.    

## Tasklist

 - [x] CHANGELOG-FORK.md entry ([CHANGELOG](https://github.com/Telenav/osrm-backend/wiki/CHANGELOG))
 - [ ] [profiles/CHANGELOG.md](https://github.com/Telenav/osrm-backend/blob/master/profiles/CHANGELOG.md) entry if any `Lua` changes   
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)


## Prerequirements
- Want to contribute? Great! First, please read this page [Contribution Guidelines](https://github.com/Telenav/osrm-backend/wiki/Contribution-Guidelines).    
- If your PR is still work in progress please attach the relevant label.    
