### PR TITLE
Build nodes2way DB when compile mapdata

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -18,6 +18,8 @@ Changes from v10.1.0
   - CHANGED `nodes2way-builder` to improve the db building performance [#281](https://github.com/Telenav/osrm-backend/pull/281)
 - Tools:    
   - CHANGED pull request template for easy using [#283](https://github.com/Telenav/osrm-backend/pull/283)     
+  - ADDED `nodes2way.db` build process when compile data [#286](https://github.com/Telenav/osrm-backend/pull/286)     
+  - ADDED `nodes2way.db.snappy` into `osrm-backend-within-mapdata` docker image [#286](https://github.com/Telenav/osrm-backend/pull/286)    
 - Docs:    
   - ADDED CHANGELOG-FORK.md for keeping changelogs of this forked repo [#283](https://github.com/Telenav/osrm-backend/pull/283)
 

--- a/docker-orchestration/osrm-backend-within-mapdata/Dockerfile
+++ b/docker-orchestration/osrm-backend-within-mapdata/Dockerfile
@@ -30,7 +30,7 @@ COPY ./map/map.osrm.tls /osrm-data/
 COPY ./map/map.osrm.turn_duration_penalties /osrm-data/
 COPY ./map/map.osrm.turn_penalties_index /osrm-data/
 COPY ./map/map.osrm.turn_weight_penalties /osrm-data/
-COPY ./map/wayid2nodeids.csv.snappy /osrm-data/
+COPY ./map/*.snappy /osrm-data/
 
 EXPOSE 5000
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
# Issue

- Targeting issue: the issue will be CLOSED once the PR merged. If there is no issue that addresses the problem, please open a corresponding issue and link it here. Uses the [Closes keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close them automatically.     

Closes https://github.com/Telenav/osrm-backend/issues/284

- Any other related issue? Mention them here.    

## Description    
A summary description for what the PR achieves.           

- Build nodes2way DB after osrm mapdata compiled 
- Package `nodes2way.db.snappy` into `osrm-backend-within-mapdata` docker

## Tasklist

 - [x] CHANGELOG-FORK.md entry ([CHANGELOG](https://github.com/Telenav/osrm-backend/wiki/CHANGELOG))
 - [ ] [profiles/CHANGELOG.md](https://github.com/Telenav/osrm-backend/blob/master/profiles/CHANGELOG.md) entry if any `Lua` changes   
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)


## Prerequirements
- Want to contribute? Great! First, please read this page [Contribution Guidelines](https://github.com/Telenav/osrm-backend/wiki/Contribution-Guidelines).    
- If your PR is still work in progress please attach the relevant label.    
