### PR TITLE
Expose Annotation/ways

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -2,7 +2,9 @@
 # Unreleased
 Changes from v10.2.0      
 - Feature:    
+  - ADDED **HTTP API** `annotation/ways` in OSRM route response after `osrm-ranking` process(retrieve `annotation/ways` from `annotation/nodes`) [#296](https://github.com/Telenav/osrm-backend/pull/296)     
 - Bugfix:    
+  - CHANGED `osrm-ranking` parsing of OSRM route response to compatible with `string` array `annotation/nodes` [#296](https://github.com/Telenav/osrm-backend/pull/296)     
 - Performance:    
 - Tools:    
 - Docs:    

--- a/integration/cmd/osrm-ranking/flags.go
+++ b/integration/cmd/osrm-ranking/flags.go
@@ -8,6 +8,7 @@ var flags struct {
 	listenPort int
 
 	wayID2NodeIDsMappingFile string
+	nodes2WayDB              string
 
 	historicalSpeed                 bool // whether enable historical speed or not
 	historicalSpeedDailyPatternFile string
@@ -20,6 +21,7 @@ func init() {
 	flag.IntVar(&flags.listenPort, "p", 8080, "Listen port.")
 
 	flag.StringVar(&flags.wayID2NodeIDsMappingFile, "m", "wayid2nodeids.csv.snappy", "OSRM way id to node ids mapping table, snappy compressed.")
+	flag.StringVar(&flags.nodes2WayDB, "nodes2way", "nodes2way.db", "BoltDB for querying wayIDs from nodeIDs.")
 
 	flag.BoolVar(&flags.historicalSpeed, "hs", false, "Enable historical speed. The historical speed related files won't be loaded if disabled.")
 	flag.StringVar(&flags.historicalSpeedDailyPatternFile, "hs-dailypattern", "", "Historical speed daily patterns csv file.")

--- a/integration/cmd/osrm-ranking/main.go
+++ b/integration/cmd/osrm-ranking/main.go
@@ -35,6 +35,7 @@ func main() {
 		glog.Errorf("Load nodes2way DB failed, err: %v", err)
 		return
 	}
+	monitorContents.Nodes2WayDB = nodes2wayDB.Statistics()
 
 	// prepare historical speeds if available
 	var hs *historicalspeed.Speeds

--- a/integration/cmd/osrm-ranking/monitor.go
+++ b/integration/cmd/osrm-ranking/monitor.go
@@ -10,6 +10,7 @@ type monitorContents struct {
 	HistoricalSpeedMonitorContents *historicalSpeedMonitorContents `json:"historical_speed"`
 	TrafficCacheMonitorContents    *trafficCacheMonitorContents    `json:"traffic_cache"`
 	WayID2NodeIDsMonitorContents   *wayID2NodeIDsMonitorContents   `json:"wayid2nodeids"`
+	Nodes2WayDB                    string                          `json:"nodes2way"`
 	CmdlineArgs                    []string                        `json:"cmdline"`
 }
 
@@ -34,7 +35,7 @@ type historicalSpeedMonitorContents struct {
 
 func newMonitorContents() *monitorContents {
 	return &monitorContents{
-		0, &historicalSpeedMonitorContents{}, &trafficCacheMonitorContents{}, &wayID2NodeIDsMonitorContents{}, nil,
+		0, &historicalSpeedMonitorContents{}, &trafficCacheMonitorContents{}, &wayID2NodeIDsMonitorContents{}, "", nil,
 	}
 }
 

--- a/integration/pkg/api/osrm/route/response.go
+++ b/integration/pkg/api/osrm/route/response.go
@@ -78,6 +78,7 @@ func (a *Annotation) UnmarshalJSON(bs []byte) error {
 		Duration    []float64     `json:"duration,omitempty"`
 		DataSources []int         `json:"datasources,omitempty"`
 		Nodes       []json.Number `json:"nodes,omitempty"`
+		Ways        []int64       `json:"ways,omitempty"` // NOT osrm original
 		Weight      []float64     `json:"weight,omitempty"`
 		Speed       []float64     `json:"speed,omitempty"`
 		Metadata    *Metadata     `json:"metadata,omitempty"`
@@ -102,6 +103,7 @@ func (a *Annotation) UnmarshalJSON(bs []byte) error {
 	a.Distance = tmp.Distance
 	a.Duration = tmp.Duration
 	a.DataSources = tmp.DataSources
+	a.Ways = tmp.Ways
 	a.Weight = tmp.Weight
 	a.Speed = tmp.Speed
 	a.Metadata = tmp.Metadata

--- a/integration/pkg/api/osrm/route/response.go
+++ b/integration/pkg/api/osrm/route/response.go
@@ -57,6 +57,7 @@ type Annotation struct {
 	Duration    []float64 `json:"duration,omitempty"`
 	DataSources []int     `json:"datasources,omitempty"`
 	Nodes       []int64   `json:"nodes,omitempty"`
+	Ways        []int64   `json:"ways,omitempty"` // NOT osrm original
 	Weight      []float64 `json:"weight,omitempty"`
 	Speed       []float64 `json:"speed,omitempty"`
 	Metadata    *Metadata `json:"metadata,omitempty"`

--- a/integration/service/ranking/handler.go
+++ b/integration/service/ranking/handler.go
@@ -66,10 +66,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if osrmResponse.Code == code.OK {
-
 		if err := h.retrieveWayIDs(osrmResponse.Routes); err != nil {
 			glog.Warning(err)
-			fmt.Fprintf(w, "%v", err)
+			fmt.Fprintf(w, "Retrieve ways from nodes failed, err: %v", err)
 			return
 		}
 

--- a/integration/service/ranking/retrieve_ways.go
+++ b/integration/service/ranking/retrieve_ways.go
@@ -1,11 +1,17 @@
 package ranking
 
 import (
+	"time"
+
 	"github.com/Telenav/osrm-backend/integration/pkg/api/osrm/route"
+	"github.com/golang/glog"
 )
 
 func (h *Handler) retrieveWayIDs(routes []*route.Route) error {
 
+	startTime := time.Now()
+
+	var waysCount, nodesCount int
 	for _, r := range routes {
 		for _, l := range r.Legs {
 			if l != nil && l.Annotation != nil {
@@ -14,8 +20,13 @@ func (h *Handler) retrieveWayIDs(routes []*route.Route) error {
 					return err
 				}
 				l.Annotation.Ways = wayIDs
+
+				nodesCount += len(l.Annotation.Nodes)
+				waysCount += len(l.Annotation.Ways)
 			}
 		}
 	}
+
+	glog.V(2).Infof("Retrieved %d wayIDs from %d nodeIDs, takes %f seconds.", waysCount, nodesCount, time.Now().Sub(startTime).Seconds())
 	return nil
 }

--- a/integration/service/ranking/retrieve_ways.go
+++ b/integration/service/ranking/retrieve_ways.go
@@ -1,0 +1,21 @@
+package ranking
+
+import (
+	"github.com/Telenav/osrm-backend/integration/pkg/api/osrm/route"
+)
+
+func (h *Handler) retrieveWayIDs(routes []*route.Route) error {
+
+	for _, r := range routes {
+		for _, l := range r.Legs {
+			if l != nil && l.Annotation != nil {
+				wayIDs, err := h.nodes2WayQuerier.QueryWays(l.Annotation.Nodes)
+				if err != nil {
+					return err
+				}
+				l.Annotation.Ways = wayIDs
+			}
+		}
+	}
+	return nil
+}

--- a/integration/service/ranking/retrieve_ways.go
+++ b/integration/service/ranking/retrieve_ways.go
@@ -11,7 +11,7 @@ func (h *Handler) retrieveWayIDs(routes []*route.Route) error {
 
 	startTime := time.Now()
 
-	var waysCount, nodesCount int
+	var legsCount, waysCount, nodesCount int
 	for _, r := range routes {
 		for _, l := range r.Legs {
 			if l != nil && l.Annotation != nil {
@@ -21,12 +21,13 @@ func (h *Handler) retrieveWayIDs(routes []*route.Route) error {
 				}
 				l.Annotation.Ways = wayIDs
 
+				legsCount++
 				nodesCount += len(l.Annotation.Nodes)
 				waysCount += len(l.Annotation.Ways)
 			}
 		}
 	}
 
-	glog.V(2).Infof("Retrieved %d wayIDs from %d nodeIDs, takes %f seconds.", waysCount, nodesCount, time.Now().Sub(startTime).Seconds())
+	glog.V(2).Infof("Retrieved %d wayIDs from %d nodeIDs for %d legs(%d routes), takes %f seconds.", waysCount, nodesCount, legsCount, len(routes), time.Now().Sub(startTime).Seconds())
 	return nil
 }

--- a/integration/service/ranking/route_by_osrm.go
+++ b/integration/service/ranking/route_by_osrm.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/Telenav/osrm-backend/integration/pkg/api/osrm/route"
 	"github.com/Telenav/osrm-backend/integration/pkg/backend"
@@ -14,6 +15,8 @@ func (h *Handler) routeByOSRM(osrmRequest *route.Request) (*route.Response, int,
 	if osrmRequest == nil {
 		return nil, http.StatusBadRequest, fmt.Errorf("empty osrm request")
 	}
+
+	startTime := time.Now()
 
 	osrmRequestURL := "http://" + h.osrmBackend + osrmRequest.RequestURI()
 	glog.Infof("osrm request to backend: %s", osrmRequestURL)
@@ -33,8 +36,8 @@ func (h *Handler) routeByOSRM(osrmRequest *route.Request) (*route.Response, int,
 		glog.V(3).Info(resp.Body)
 		return nil, resp.StatusCode, err
 	}
-	glog.Infof("osrm response from backend, http status %d, response code %s, message %s, data_version %s",
-		resp.StatusCode, routeResponse.Code, routeResponse.Message, routeResponse.DataVersion)
+	glog.Infof("osrm response received from backend, http status %d, response code %s, message %s, data_version %s, takes %f seconds.",
+		resp.StatusCode, routeResponse.Code, routeResponse.Message, routeResponse.DataVersion, time.Now().Sub(startTime).Seconds())
 	glog.V(3).Infof("osrm response from backend: %v", routeResponse)
 
 	return &routeResponse, resp.StatusCode, nil


### PR DESCRIPTION
# Issue

- Targeting issue: the issue will be CLOSED once the PR merged. If there is no issue that addresses the problem, please open a corresponding issue and link it here. Uses the [Closes keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close them automatically.     
Closes https://github.com/Telenav/osrm-backend/issues/257

- Any other related issue? Mention them here.    

## Description    
A summary description for what the PR achieves.           

- `Annotation/Nodes` compatible with both int64 array and string array incoming;   
- Add `Ways` in `Annotation` of OSRM API; 
- Load and monitor `nodes2way.db` in `osrm-ranking`;    
- Retrieve `annotation/ways` from `annotation/nodes` when recieved OSRM route response;   

Be aware that you may still see invalid nodeIDs(similar with https://github.com/Telenav/osrm-backend/issues/276) after `osrm-ranking`. It's limited by `Javascript/JSON` parsing(see more in https://github.com/callumlocke/json-formatter#why-are-large-numbers-not-displayed-accurately). Simply disable your brower extension's automatically parsing, you'll see correct values.     

## Tasklist

 - [x] CHANGELOG-FORK.md entry ([CHANGELOG](https://github.com/Telenav/osrm-backend/wiki/CHANGELOG))
 - [ ] [profiles/CHANGELOG.md](https://github.com/Telenav/osrm-backend/blob/master/profiles/CHANGELOG.md) entry if any `Lua` changes   
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)


## Prerequirements
- Want to contribute? Great! First, please read this page [Contribution Guidelines](https://github.com/Telenav/osrm-backend/wiki/Contribution-Guidelines).    
- If your PR is still work in progress please attach the relevant label.    
