### PR TITLE
Use way indexed live traffic cache in osrm-ranking

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -4,6 +4,7 @@ Changes from v10.2.0
 - Feature:    
   - ADDED **HTTP API** `annotation/ways` in OSRM route response after `osrm-ranking` process(retrieve `annotation/ways` from `annotation/nodes`) [#296](https://github.com/Telenav/osrm-backend/pull/296)    
   - CHANGED for internal refactoring, moved `unidbpatch` and `mapsource` packages into `integration/util` folder [#300](https://github.com/Telenav/osrm-backend/pull/300)
+  - CHANGED live traffic cache from edge indexed to way indexed in `osrm-ranking` []()
 - Bugfix:    
   - CHANGED `osrm-ranking` parsing of OSRM route response to compatible with `string` array `annotation/nodes` [#296](https://github.com/Telenav/osrm-backend/pull/296)     
 - Performance:    

--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -4,7 +4,7 @@ Changes from v10.2.0
 - Feature:    
   - ADDED **HTTP API** `annotation/ways` in OSRM route response after `osrm-ranking` process(retrieve `annotation/ways` from `annotation/nodes`) [#296](https://github.com/Telenav/osrm-backend/pull/296)    
   - CHANGED for internal refactoring, moved `unidbpatch` and `mapsource` packages into `integration/util` folder [#300](https://github.com/Telenav/osrm-backend/pull/300)
-  - CHANGED live traffic cache from edge indexed to way indexed in `osrm-ranking` []()
+  - CHANGED live traffic cache from edge indexed to way indexed in `osrm-ranking` [#303](https://github.com/Telenav/osrm-backend/pull/303)
 - Bugfix:    
   - CHANGED `osrm-ranking` parsing of OSRM route response to compatible with `string` array `annotation/nodes` [#296](https://github.com/Telenav/osrm-backend/pull/296)     
 - Performance:    

--- a/integration/cmd/osrm-ranking/flags.go
+++ b/integration/cmd/osrm-ranking/flags.go
@@ -7,8 +7,7 @@ import (
 var flags struct {
 	listenPort int
 
-	wayID2NodeIDsMappingFile string
-	nodes2WayDB              string
+	nodes2WayDB string
 
 	historicalSpeed                 bool // whether enable historical speed or not
 	historicalSpeedDailyPatternFile string
@@ -20,7 +19,6 @@ var flags struct {
 func init() {
 	flag.IntVar(&flags.listenPort, "p", 8080, "Listen port.")
 
-	flag.StringVar(&flags.wayID2NodeIDsMappingFile, "m", "wayid2nodeids.csv.snappy", "OSRM way id to node ids mapping table, snappy compressed.")
 	flag.StringVar(&flags.nodes2WayDB, "nodes2way", "nodes2way.db", "BoltDB for querying wayIDs from nodeIDs.")
 
 	flag.BoolVar(&flags.historicalSpeed, "hs", false, "Enable historical speed. The historical speed related files won't be loaded if disabled.")

--- a/integration/cmd/osrm-ranking/monitor.go
+++ b/integration/cmd/osrm-ranking/monitor.go
@@ -7,25 +7,17 @@ import (
 
 type monitorContents struct {
 	UpTime                         jsonDuration                    `json:"uptime"`
-	HistoricalSpeedMonitorContents *historicalSpeedMonitorContents `json:"historical_speed"`
-	TrafficCacheMonitorContents    *trafficCacheMonitorContents    `json:"traffic_cache"`
-	WayID2NodeIDsMonitorContents   *wayID2NodeIDsMonitorContents   `json:"wayid2nodeids"`
+	HistoricalSpeedMonitorContents *historicalSpeedMonitorContents `json:"historical speed"`
+	TrafficCacheMonitorContents    *trafficCacheMonitorContents    `json:"live traffic"`
 	Nodes2WayDB                    string                          `json:"nodes2way"`
 	CmdlineArgs                    []string                        `json:"cmdline"`
 }
 
 type trafficCacheMonitorContents struct {
-	Name                   string `json:"name"`
-	Flows                  int64  `json:"flows"`
-	FlowsAffectedWays      int64  `json:"flows_affected_ways"`
-	Incidents              int    `json:"incidents"`
-	IncidentsAffectedWays  int    `json:"incidents_affected_ways"`
-	IncidentsAffectedEdges int    `json:"incidents_affected_edges"`
-}
-
-type wayID2NodeIDsMonitorContents struct {
-	IsReady bool `json:"is_ready"`
-	Ways    int  `json:"ways"`
+	Flows                  int64 `json:"flows"`
+	Incidents              int   `json:"block_incidents"`
+	IncidentsAffectedWays  int   `json:"incidents_affected_ways"`
+	IncidentsAffectedEdges int   `json:"incidents_affected_edges"`
 }
 
 type historicalSpeedMonitorContents struct {
@@ -35,7 +27,7 @@ type historicalSpeedMonitorContents struct {
 
 func newMonitorContents() *monitorContents {
 	return &monitorContents{
-		0, &historicalSpeedMonitorContents{}, &trafficCacheMonitorContents{}, &wayID2NodeIDsMonitorContents{}, "", nil,
+		0, &historicalSpeedMonitorContents{}, &trafficCacheMonitorContents{}, "", nil,
 	}
 }
 

--- a/integration/service/ranking/handler.go
+++ b/integration/service/ranking/handler.go
@@ -20,12 +20,12 @@ import (
 // Handler represents a handler for ranking.
 type Handler struct {
 	nodes2WayQuerier waysnodes.WaysQuerier
-	trafficInquirer  livetraffic.QuerierByEdge
+	trafficQuerier   livetraffic.Querier
 	osrmBackend      string
 }
 
 // New creates a new handler for ranking.
-func New(osrmBackend string, nodes2WayQuerier waysnodes.WaysQuerier, trafficInquirer livetraffic.QuerierByEdge) *Handler {
+func New(osrmBackend string, nodes2WayQuerier waysnodes.WaysQuerier, trafficQuerier livetraffic.Querier) *Handler {
 	if nodes2WayQuerier == nil {
 		glog.Fatal("nil nodes2WayQuerier")
 		return nil
@@ -33,7 +33,7 @@ func New(osrmBackend string, nodes2WayQuerier waysnodes.WaysQuerier, trafficInqu
 
 	return &Handler{
 		nodes2WayQuerier,
-		trafficInquirer,
+		trafficQuerier,
 		osrmBackend,
 	}
 }
@@ -72,7 +72,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		if h.trafficInquirer != nil {
+		if h.trafficQuerier != nil {
 			// update speeds,durations,datasources by traffic
 			osrmResponse.Routes = h.updateRoutesByTraffic(osrmResponse.Routes)
 		}


### PR DESCRIPTION
# Issue

- Targeting issue: the issue will be CLOSED once the PR merged. If there is no issue that addresses the problem, please open a corresponding issue and link it here. Uses the [Closes keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close them automatically.     
Resolves https://github.com/Telenav/osrm-backend/issues/297

- Any other related issue? Mention them here.    

## Description    
A summary description for what the PR achieves.           

- use way indexed live traffic cache instead of edge indexed in `osrm-ranking`

## Tasklist

 - [x] CHANGELOG-FORK.md entry ([CHANGELOG](https://github.com/Telenav/osrm-backend/wiki/CHANGELOG))
 - [ ] [profiles/CHANGELOG.md](https://github.com/Telenav/osrm-backend/blob/master/profiles/CHANGELOG.md) entry if any `Lua` changes   
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)


## Prerequirements
- Want to contribute? Great! First, please read this page [Contribution Guidelines](https://github.com/Telenav/osrm-backend/wiki/Contribution-Guidelines).    
- If your PR is still work in progress please attach the relevant label.    
