### PR TITLE
Add `merge=union` for resolving merge confilcits automatically on CHANGELOG-FORK.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,6 @@
 
 # Declare files that will always have LF line endings on checkout.
 *.sh text eol=lf
+
+# Resolve merge conflicts automatically
+CHANGELOG-FORK.md merge=union

--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -8,6 +8,7 @@ Changes from v10.2.0
   - CHANGED `osrm-ranking` parsing of OSRM route response to compatible with `string` array `annotation/nodes` [#296](https://github.com/Telenav/osrm-backend/pull/296)     
 - Performance:    
 - Tools:    
+  - ADDED `merge=union` for resolving merge conflicits automatically on `CHANGELOG-FORK.md` []()
 - Docs:    
 
 

--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -8,7 +8,7 @@ Changes from v10.2.0
   - CHANGED `osrm-ranking` parsing of OSRM route response to compatible with `string` array `annotation/nodes` [#296](https://github.com/Telenav/osrm-backend/pull/296)     
 - Performance:    
 - Tools:    
-  - ADDED `merge=union` for resolving merge conflicits automatically on `CHANGELOG-FORK.md` []()
+  - ADDED `merge=union` for resolving merge conflicits automatically on `CHANGELOG-FORK.md` [#305](https://github.com/Telenav/osrm-backend/pull/305)
 - Docs:    
 
 


### PR DESCRIPTION
# Issue

- Targeting issue: the issue will be CLOSED once the PR merged. If there is no issue that addresses the problem, please open a corresponding issue and link it here. Uses the [Closes keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close them automatically.     
Resolves https://github.com/Telenav/osrm-backend/issues/304

- Any other related issue? Mention them here.    

## Description    
A summary description for what the PR achieves.           

- Add `merge=union` for resolving merge confilcits automatically on `CHANGELOG-FORK.md`

Be aware that it's not supported by GitHub but only locally(works on GitLab, not sure on Bitbucket). But anyway, it can help at least on local. And let's keep an eye on GitHub to see when it can rollout the feature.             

## Tasklist

 - [x] CHANGELOG-FORK.md entry ([CHANGELOG](https://github.com/Telenav/osrm-backend/wiki/CHANGELOG))
 - [ ] [profiles/CHANGELOG.md](https://github.com/Telenav/osrm-backend/blob/master/profiles/CHANGELOG.md) entry if any `Lua` changes   
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)


## Prerequirements
- Want to contribute? Great! First, please read this page [Contribution Guidelines](https://github.com/Telenav/osrm-backend/wiki/Contribution-Guidelines).    
- If your PR is still work in progress please attach the relevant label.    
