### PR TITLE
Recalculate by traffic

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -6,6 +6,10 @@ Changes from v10.2.0
   - CHANGED for internal refactoring, moved `unidbpatch` and `mapsource` packages into `integration/util` folder [#300](https://github.com/Telenav/osrm-backend/pull/300)
   - CHANGED live traffic cache from edge indexed to way indexed in `osrm-ranking` [#303](https://github.com/Telenav/osrm-backend/pull/303)
   - REMOVED edge indexed live traffic cache in `osrm-ranking` [#308](https://github.com/Telenav/osrm-backend/pull/308)
+  - ADDED **HTTP API** `annotation/live_traffic_speed`, `annotation/live_traffic_level`, `annotation/block_incident`, `annotation/historical_speed` in OSRM route response after `osrm-ranking` process [#310](https://github.com/Telenav/osrm-backend/pull/310)    
+  - ADDED **HTTP API** query parameters `live_traffic=true/false`, `historical_speed=true/false` in request against `osrm-ranking` to support enable/disable traffic on the fly [#310](https://github.com/Telenav/osrm-backend/pull/310)      
+  - ADDED cmd parameter `-live-traffic` to enable/disable live traffic when startup `osrm-ranking` [#310](https://github.com/Telenav/osrm-backend/pull/310)      
+  - ADDED re-calculate `duration/weight` by traffic applying model `preferlivetraffic` in `osrm-ranking`, also support to use model `appendonly` by cmd parameter [#310](https://github.com/Telenav/osrm-backend/pull/310)    
 - Bugfix:    
   - CHANGED `osrm-ranking` parsing of OSRM route response to compatible with `string` array `annotation/nodes` [#296](https://github.com/Telenav/osrm-backend/pull/296)     
 - Performance:    

--- a/integration/cmd/osrm-ranking/flags.go
+++ b/integration/cmd/osrm-ranking/flags.go
@@ -9,6 +9,7 @@ var flags struct {
 
 	nodes2WayDB string
 
+	liveTraffic                     bool // whether enable live traffic or not
 	historicalSpeed                 bool // whether enable historical speed or not
 	historicalSpeedDailyPatternFile string
 	historicalSpeedWaysMappingFile  string
@@ -21,6 +22,7 @@ func init() {
 
 	flag.StringVar(&flags.nodes2WayDB, "nodes2way", "nodes2way.db", "BoltDB for querying wayIDs from nodeIDs.")
 
+	flag.BoolVar(&flags.liveTraffic, "live-traffic", false, "Enable live traffic. ")
 	flag.BoolVar(&flags.historicalSpeed, "hs", false, "Enable historical speed. The historical speed related files won't be loaded if disabled.")
 	flag.StringVar(&flags.historicalSpeedDailyPatternFile, "hs-dailypattern", "", "Historical speed daily patterns csv file.")
 	flag.StringVar(&flags.historicalSpeedWaysMappingFile, "hs-waysmapping", "", "Historical speed wayIDs to daily patterns mapping csv file. Pass in multiple files separated by ','.")

--- a/integration/cmd/osrm-ranking/flags.go
+++ b/integration/cmd/osrm-ranking/flags.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"flag"
+	"strings"
+
+	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel/modelfactory"
 )
 
 var flags struct {
@@ -13,6 +16,8 @@ var flags struct {
 	historicalSpeed                 bool // whether enable historical speed or not
 	historicalSpeedDailyPatternFile string
 	historicalSpeedWaysMappingFile  string
+
+	trafficApplyingModel string
 
 	osrmBackendEndpoint string
 }
@@ -26,6 +31,8 @@ func init() {
 	flag.BoolVar(&flags.historicalSpeed, "hs", false, "Enable historical speed. The historical speed related files won't be loaded if disabled.")
 	flag.StringVar(&flags.historicalSpeedDailyPatternFile, "hs-dailypattern", "", "Historical speed daily patterns csv file.")
 	flag.StringVar(&flags.historicalSpeedWaysMappingFile, "hs-waysmapping", "", "Historical speed wayIDs to daily patterns mapping csv file. Pass in multiple files separated by ','.")
+
+	flag.StringVar(&flags.trafficApplyingModel, "traffic-applying-model", modelfactory.DefaultModelName(), "Model to apply traffic on route, options: "+strings.Join(modelfactory.AvailableModelNames(), ","))
 
 	flag.StringVar(&flags.osrmBackendEndpoint, "osrm", "", "Backend OSRM-backend endpoint")
 }

--- a/integration/cmd/osrm-ranking/flags.go
+++ b/integration/cmd/osrm-ranking/flags.go
@@ -28,9 +28,9 @@ func init() {
 	flag.StringVar(&flags.nodes2WayDB, "nodes2way", "nodes2way.db", "BoltDB for querying wayIDs from nodeIDs.")
 
 	flag.BoolVar(&flags.liveTraffic, "live-traffic", false, "Enable live traffic. ")
-	flag.BoolVar(&flags.historicalSpeed, "hs", false, "Enable historical speed. The historical speed related files won't be loaded if disabled.")
-	flag.StringVar(&flags.historicalSpeedDailyPatternFile, "hs-dailypattern", "", "Historical speed daily patterns csv file.")
-	flag.StringVar(&flags.historicalSpeedWaysMappingFile, "hs-waysmapping", "", "Historical speed wayIDs to daily patterns mapping csv file. Pass in multiple files separated by ','.")
+	flag.BoolVar(&flags.historicalSpeed, "historical-speed", false, "Enable historical speed. The historical speed related files won't be loaded if disabled.")
+	flag.StringVar(&flags.historicalSpeedDailyPatternFile, "historical-speed-dailypattern", "", "Historical speed daily patterns csv file.")
+	flag.StringVar(&flags.historicalSpeedWaysMappingFile, "historical-speed-waysmapping", "", "Historical speed wayIDs to daily patterns mapping csv file. Pass in multiple files separated by ','.")
 
 	flag.StringVar(&flags.trafficApplyingModel, "traffic-applying-model", modelfactory.DefaultModelName(), "Model to apply traffic on route, options: "+strings.Join(modelfactory.AvailableModelNames(), ","))
 

--- a/integration/cmd/osrm-ranking/main.go
+++ b/integration/cmd/osrm-ranking/main.go
@@ -79,9 +79,10 @@ func main() {
 		if liveTrafficCache != nil {
 			monitorContents.TrafficCacheMonitorContents.Flows = liveTrafficCache.Flows.Count()
 			monitorContents.TrafficCacheMonitorContents.Incidents = liveTrafficCache.Incidents.Count()
-			glog.Infof("monitor live traffic, [flows] %d, [incidents] blocking-only %d, affectedways %d affectededges %d",
+			monitorContents.TrafficCacheMonitorContents.IncidentsAffectedWays = liveTrafficCache.Incidents.AffectedWaysCount()
+			glog.Infof("monitor live traffic, [flows] %d, [incidents] blocking-only %d, affectedways %d.",
 				monitorContents.TrafficCacheMonitorContents.Flows,
-				monitorContents.TrafficCacheMonitorContents.Incidents, monitorContents.TrafficCacheMonitorContents.IncidentsAffectedWays, monitorContents.TrafficCacheMonitorContents.IncidentsAffectedEdges)
+				monitorContents.TrafficCacheMonitorContents.Incidents, monitorContents.TrafficCacheMonitorContents.IncidentsAffectedWays)
 		}
 
 		w.WriteHeader(http.StatusOK)

--- a/integration/cmd/osrm-ranking/main.go
+++ b/integration/cmd/osrm-ranking/main.go
@@ -38,16 +38,16 @@ func main() {
 	monitorContents.Nodes2WayDB = nodes2wayDB.Statistics()
 
 	// prepare historical speeds if available
-	var hs *historicalspeed.Speeds
+	var historicalSpeedCache *historicalspeed.Speeds
 	if flags.historicalSpeed {
-		hs = historicalspeed.New(strings.Split(flags.historicalSpeedDailyPatternFile, ","), strings.Split(flags.historicalSpeedWaysMappingFile, ","))
-		if err := hs.Load(); err != nil {
+		historicalSpeedCache = historicalspeed.New(strings.Split(flags.historicalSpeedDailyPatternFile, ","), strings.Split(flags.historicalSpeedWaysMappingFile, ","))
+		if err := historicalSpeedCache.Load(); err != nil {
 			glog.Errorf("Load historical speed failed, err: %v", err)
 			return
 		}
-		glog.Infof("Historical speeds loaded: daily patterns count %d, ways(directed) count %d.", hs.DailyPatternsCount(), hs.WaysCount())
-		monitorContents.HistoricalSpeedMonitorContents.DailyPatterns = hs.DailyPatternsCount()
-		monitorContents.HistoricalSpeedMonitorContents.Way2PatternsMapping = hs.WaysCount()
+		glog.Infof("Historical speeds loaded: daily patterns count %d, ways(directed) count %d.", historicalSpeedCache.DailyPatternsCount(), historicalSpeedCache.WaysCount())
+		monitorContents.HistoricalSpeedMonitorContents.DailyPatterns = historicalSpeedCache.DailyPatternsCount()
+		monitorContents.HistoricalSpeedMonitorContents.Way2PatternsMapping = historicalSpeedCache.WaysCount()
 	}
 
 	// prepare traffic cache
@@ -91,9 +91,9 @@ func main() {
 
 	//start ranking service
 	var trafficApplier trafficapplyingmodel.Applier
-	if liveTrafficCache != nil || hs != nil {
+	if liveTrafficCache != nil || historicalSpeedCache != nil {
 		var err error
-		trafficApplier, err = modelfactory.NewApplier(flags.trafficApplyingModel, liveTrafficCache, hs)
+		trafficApplier, err = modelfactory.NewApplier(flags.trafficApplyingModel, liveTrafficCache, historicalSpeedCache)
 		if err != nil {
 			glog.Errorf("New traffic applying model failed, err %v", err)
 			return

--- a/integration/cmd/osrm-ranking/monitor.go
+++ b/integration/cmd/osrm-ranking/monitor.go
@@ -14,10 +14,9 @@ type monitorContents struct {
 }
 
 type trafficCacheMonitorContents struct {
-	Flows                  int64 `json:"flows"`
-	Incidents              int   `json:"block_incidents"`
-	IncidentsAffectedWays  int   `json:"incidents_affected_ways"`
-	IncidentsAffectedEdges int   `json:"incidents_affected_edges"`
+	Flows                 int64 `json:"flows"`
+	Incidents             int   `json:"block_incidents"`
+	IncidentsAffectedWays int   `json:"incidents_affected_ways"`
 }
 
 type historicalSpeedMonitorContents struct {

--- a/integration/pkg/api/osrm/route/response.go
+++ b/integration/pkg/api/osrm/route/response.go
@@ -53,14 +53,18 @@ type Waypoint struct {
 
 // Annotation of the whole route leg with fine-grained information about each segment or node id.
 type Annotation struct {
-	Distance    []float64 `json:"distance,omitempty"`
-	Duration    []float64 `json:"duration,omitempty"`
-	DataSources []int     `json:"datasources,omitempty"`
-	Nodes       []int64   `json:"nodes,omitempty"`
-	Ways        []int64   `json:"ways,omitempty"` // NOT osrm original
-	Weight      []float64 `json:"weight,omitempty"`
-	Speed       []float64 `json:"speed,omitempty"`
-	Metadata    *Metadata `json:"metadata,omitempty"`
+	Distance         []float64 `json:"distance,omitempty"`
+	Duration         []float64 `json:"duration,omitempty"`
+	DataSources      []int     `json:"datasources,omitempty"`
+	Nodes            []int64   `json:"nodes,omitempty"`
+	Ways             []int64   `json:"ways,omitempty"` // NOT osrm original
+	Weight           []float64 `json:"weight,omitempty"`
+	Speed            []float64 `json:"speed,omitempty"`
+	LiveTrafficSpeed []float64 `json:"live_traffic_speed,omitempty"` // NOT osrm original
+	LiveTrafficLevel []int     `json:"live_traffic_level,omitempty"` // NOT osrm original
+	BlockIncident    []bool    `json:"block_incident,omitempty"`     // NOT osrm original
+	HistoricalSpeed  []float64 `json:"historical_speed,omitempty"`   // NOT osrm original
+	Metadata         *Metadata `json:"metadata,omitempty"`
 }
 
 // Metadata related to other annotations
@@ -74,14 +78,18 @@ func (a *Annotation) UnmarshalJSON(bs []byte) error {
 
 	// A temporary type that uses json.Number instead of int64
 	var tmp struct {
-		Distance    []float64     `json:"distance,omitempty"`
-		Duration    []float64     `json:"duration,omitempty"`
-		DataSources []int         `json:"datasources,omitempty"`
-		Nodes       []json.Number `json:"nodes,omitempty"`
-		Ways        []int64       `json:"ways,omitempty"` // NOT osrm original
-		Weight      []float64     `json:"weight,omitempty"`
-		Speed       []float64     `json:"speed,omitempty"`
-		Metadata    *Metadata     `json:"metadata,omitempty"`
+		Distance         []float64     `json:"distance,omitempty"`
+		Duration         []float64     `json:"duration,omitempty"`
+		DataSources      []int         `json:"datasources,omitempty"`
+		Nodes            []json.Number `json:"nodes,omitempty"`
+		Ways             []int64       `json:"ways,omitempty"` // NOT osrm original
+		Weight           []float64     `json:"weight,omitempty"`
+		Speed            []float64     `json:"speed,omitempty"`
+		LiveTrafficSpeed []float64     `json:"live_traffic_speed,omitempty"` // NOT osrm original
+		LiveTrafficLevel []int         `json:"live_traffic_level,omitempty"` // NOT osrm original
+		BlockIncident    []bool        `json:"block_incident,omitempty"`     // NOT osrm original
+		HistoricalSpeed  []float64     `json:"historical_speed,omitempty"`   // NOT osrm original
+		Metadata         *Metadata     `json:"metadata,omitempty"`
 	}
 
 	// Unmarshal into the temporary

--- a/integration/service/ranking/trafficapplyingmodel/appendonly/model.go
+++ b/integration/service/ranking/trafficapplyingmodel/appendonly/model.go
@@ -1,0 +1,106 @@
+// Package appendonly queries live traffic and historical speed at current clock and append to annotations on a OSRM route.
+// The live/historical speed will be set < 0 if no valid data.
+package appendonly
+
+import (
+	"time"
+
+	"github.com/Telenav/osrm-backend/integration/traffic/livetraffic/trafficproxy"
+
+	"github.com/Telenav/osrm-backend/integration/pkg/api/osrm/route"
+	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel"
+	"github.com/Telenav/osrm-backend/integration/traffic"
+)
+
+// Name represents the name of traffic applying model.
+func Name() string {
+	return "append-only"
+}
+
+// Model represents the model of applying traffic.
+type Model struct {
+	traffic.LiveTrafficQuerier
+	traffic.HistoricalSpeedQuerier
+}
+
+// New creates a new model object.
+func New(l traffic.LiveTrafficQuerier, h traffic.HistoricalSpeedQuerier) (*Model, error) {
+	if l == nil && h == nil {
+		return nil, trafficapplyingmodel.ErrNoValidTrafficQuerier
+	}
+
+	return &Model{l, h}, nil
+}
+
+// ApplyTraffic applys traffic on a route.
+func (m Model) ApplyTraffic(r *route.Route, liveTraffic bool, historicalSpeed bool) error {
+	if r == nil {
+		return trafficapplyingmodel.ErrEmptyRoute
+	}
+	if m.LiveTrafficQuerier == nil && m.HistoricalSpeedQuerier == nil {
+		return trafficapplyingmodel.ErrNoValidTrafficQuerier
+	}
+	if !liveTraffic && !historicalSpeed {
+		return nil // nothing need to do
+	}
+
+	for _, l := range r.Legs {
+		if l == nil {
+			return trafficapplyingmodel.ErrEmptyLeg
+		}
+		if err := m.applyTrafficOnAnnotation(l.Annotation, liveTraffic, historicalSpeed); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m Model) applyTrafficOnAnnotation(a *route.Annotation, enableLiveTraffic bool, enableHistoricalSpeed bool) error {
+	if a == nil {
+		return trafficapplyingmodel.ErrEmptyAnnotation
+	}
+
+	waysCount := len(a.Ways)
+
+	liveTrafficSpeeds := make([]float64, waysCount)
+	liveTrafficlevels := make([]int, waysCount)
+	blockIncidents := make([]bool, waysCount)
+	historicalSpeeds := make([]float64, waysCount)
+
+	utcTimestamp := time.Now().UTC()
+	for i := 0; i < waysCount; i++ {
+		wayID := a.Ways[i]
+
+		if m.LiveTrafficQuerier != nil && enableLiveTraffic {
+			if f := m.LiveTrafficQuerier.QueryFlow(wayID); f != nil {
+				liveTrafficSpeeds[i] = float64(f.GetSpeed())
+				liveTrafficlevels[i] = int(f.GetTrafficLevel())
+			} else {
+				liveTrafficSpeeds[i] = trafficapplyingmodel.InvalidTrafficSpeedFloat64
+				liveTrafficlevels[i] = int(trafficproxy.TrafficLevel_NO_LEVELS)
+			}
+			if m.LiveTrafficQuerier.BlockedByIncident(wayID) {
+				blockIncidents[i] = true
+			}
+		}
+
+		if m.HistoricalSpeedQuerier != nil && enableHistoricalSpeed {
+			if speed, ok := m.HistoricalSpeedQuerier.QueryHistoricalSpeed(wayID, utcTimestamp); ok {
+				historicalSpeeds[i] = speed
+			} else {
+				historicalSpeeds[i] = trafficapplyingmodel.InvalidTrafficSpeedFloat64
+			}
+		}
+	}
+
+	if m.LiveTrafficQuerier != nil && enableLiveTraffic {
+		a.LiveTrafficLevel = liveTrafficlevels
+		a.LiveTrafficSpeed = liveTrafficSpeeds
+		a.BlockIncident = blockIncidents
+	}
+	if m.HistoricalSpeedQuerier != nil && enableHistoricalSpeed {
+		a.HistoricalSpeed = historicalSpeeds
+	}
+	return nil
+}

--- a/integration/service/ranking/trafficapplyingmodel/appendonly/model.go
+++ b/integration/service/ranking/trafficapplyingmodel/appendonly/model.go
@@ -1,4 +1,5 @@
-// Package appendonly queries live traffic and historical speed at current clock and append to annotations on a OSRM route.
+// Package appendonly only additional live traffic and historical speed append to OSRM response, keep original response's duration/weight for a route.
+// It queries live traffic and historical speed at current clock and append to annotations on a OSRM route.
 // The live/historical speed will be set < 0 if no valid data.
 package appendonly
 

--- a/integration/service/ranking/trafficapplyingmodel/appendspeedonly/model.go
+++ b/integration/service/ranking/trafficapplyingmodel/appendspeedonly/model.go
@@ -1,7 +1,7 @@
-// Package appendonly only additional live traffic and historical speed append to OSRM response, keep original response's duration/weight for a route.
+// Package appendspeedonly only additional live traffic and historical speed append to OSRM response, keep original response's duration/weight for a route.
 // It queries live traffic and historical speed at current clock and append to annotations on a OSRM route.
 // The live/historical speed will be set < 0 if no valid data.
-package appendonly
+package appendspeedonly
 
 import (
 	"time"

--- a/integration/service/ranking/trafficapplyingmodel/appendspeedonly/model.go
+++ b/integration/service/ranking/trafficapplyingmodel/appendspeedonly/model.go
@@ -15,7 +15,7 @@ import (
 
 // Name represents the name of traffic applying model.
 func Name() string {
-	return "append-only"
+	return "append-speed-only"
 }
 
 // Model represents the model of applying traffic.

--- a/integration/service/ranking/trafficapplyingmodel/error.go
+++ b/integration/service/ranking/trafficapplyingmodel/error.go
@@ -1,0 +1,12 @@
+package trafficapplyingmodel
+
+import "errors"
+
+// common errors
+var (
+	ErrNoValidTrafficQuerier   = errors.New("at least one of live traffic and historical speed querier should be valid")
+	ErrEmptyRoute              = errors.New("route is nil")
+	ErrEmptyLeg                = errors.New("leg is nil")
+	ErrEmptyAnnotation         = errors.New("annotation is nil")
+	ErrEmptyAnnotationMetadata = errors.New("annotation/metadata is nil")
+)

--- a/integration/service/ranking/trafficapplyingmodel/interface.go
+++ b/integration/service/ranking/trafficapplyingmodel/interface.go
@@ -1,0 +1,11 @@
+package trafficapplyingmodel
+
+import "github.com/Telenav/osrm-backend/integration/pkg/api/osrm/route"
+
+// Applier wraps interfaces for applying traffic on OSRM route.
+type Applier interface {
+
+	// ApplyTraffic applys traffic on a route.
+	// liveTraffic and historicalSpeed are able to enable/disable the effects on the fly.
+	ApplyTraffic(r *route.Route, liveTraffic bool, historicalSpeed bool) error
+}

--- a/integration/service/ranking/trafficapplyingmodel/invalid_speed.go
+++ b/integration/service/ranking/trafficapplyingmodel/invalid_speed.go
@@ -1,0 +1,16 @@
+package trafficapplyingmodel
+
+import (
+	"github.com/Telenav/osrm-backend/integration/util"
+)
+
+// Invalid live/historical traffic speeds for applying.
+const (
+	InvalidTrafficSpeed        = -1
+	InvalidTrafficSpeedFloat64 = float64(InvalidTrafficSpeed)
+)
+
+// IsInvalidSpeed decide whether the speed is valid(>=0) or not.
+func IsInvalidSpeed(speed float64) bool {
+	return util.FloatEquals(speed, InvalidTrafficSpeedFloat64) || speed < 0
+}

--- a/integration/service/ranking/trafficapplyingmodel/modelfactory/factory.go
+++ b/integration/service/ranking/trafficapplyingmodel/modelfactory/factory.go
@@ -1,0 +1,59 @@
+// Package modelfactory provides support to create specified traffic applying model applier.
+package modelfactory
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel"
+	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel/appendonly"
+	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel/preferlivetraffic"
+	"github.com/Telenav/osrm-backend/integration/traffic"
+	"github.com/golang/glog"
+)
+
+// AvailableModelNames returns name list of all available traffic applying models.
+func AvailableModelNames() []string {
+
+	n := []string{}
+	for k := range availableModels {
+		n = append(n, k)
+	}
+	return n
+}
+
+// DefaultModelName returns the name of default traffic applying model.
+func DefaultModelName() string {
+	return defaultModel
+}
+
+// NewApplier creates a new specified traffic applier.
+func NewApplier(name string, l traffic.LiveTrafficQuerier, h traffic.HistoricalSpeedQuerier) (trafficapplyingmodel.Applier, error) {
+	if _, ok := availableModels[name]; !ok {
+		return nil, fmt.Errorf("invalid traffic applying model %s, options: %s", name, strings.Join(AvailableModelNames(), ","))
+	}
+
+	var applier trafficapplyingmodel.Applier
+	var err error
+	switch name {
+	case appendonly.Name():
+		applier, err = appendonly.New(l, h)
+	case preferlivetraffic.Name():
+		applier, err = preferlivetraffic.New(l, h)
+	default:
+		glog.Fatalf("missed traffic applying model: %s", name)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return applier, nil
+}
+
+var (
+	availableModels = map[string]struct{}{
+		appendonly.Name():        struct{}{},
+		preferlivetraffic.Name(): struct{}{},
+	}
+	defaultModel = preferlivetraffic.Name()
+)

--- a/integration/service/ranking/trafficapplyingmodel/modelfactory/factory.go
+++ b/integration/service/ranking/trafficapplyingmodel/modelfactory/factory.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel"
-	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel/appendonly"
+	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel/appendspeedonly"
 	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel/preferlivetraffic"
 	"github.com/Telenav/osrm-backend/integration/traffic"
 	"github.com/golang/glog"
@@ -36,8 +36,8 @@ func NewApplier(name string, l traffic.LiveTrafficQuerier, h traffic.HistoricalS
 	var applier trafficapplyingmodel.Applier
 	var err error
 	switch name {
-	case appendonly.Name():
-		applier, err = appendonly.New(l, h)
+	case appendspeedonly.Name():
+		applier, err = appendspeedonly.New(l, h)
 	case preferlivetraffic.Name():
 		applier, err = preferlivetraffic.New(l, h)
 	default:
@@ -52,7 +52,7 @@ func NewApplier(name string, l traffic.LiveTrafficQuerier, h traffic.HistoricalS
 
 var (
 	availableModels = map[string]struct{}{
-		appendonly.Name():        struct{}{},
+		appendspeedonly.Name():   struct{}{},
 		preferlivetraffic.Name(): struct{}{},
 	}
 	defaultModel = preferlivetraffic.Name()

--- a/integration/service/ranking/trafficapplyingmodel/preferlivetraffic/model.go
+++ b/integration/service/ranking/trafficapplyingmodel/preferlivetraffic/model.go
@@ -1,5 +1,5 @@
 // Package preferlivetraffic re-calculate duration/weight for a route, prefer to use live traffic, if no live traffic on a way then use historical speed, otherwise use the speed from Lua profile.
-// Both live traffic and historical speed will be appended to annotations on a OSRM route, same as what package appendonly provides.
+// Both live traffic and historical speed will be appended to annotations on a OSRM route, same as what package appendspeedonly provides.
 package preferlivetraffic
 
 import (
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Telenav/osrm-backend/integration/pkg/api/osrm/route"
 	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel"
-	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel/appendonly"
+	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel/appendspeedonly"
 	"github.com/Telenav/osrm-backend/integration/traffic"
 	"github.com/golang/glog"
 )
@@ -25,7 +25,7 @@ type Model struct {
 	traffic.LiveTrafficQuerier
 	traffic.HistoricalSpeedQuerier
 
-	appendOnly *appendonly.Model
+	appendOnly *appendspeedonly.Model
 }
 
 // New creates a new model object.
@@ -34,7 +34,7 @@ func New(l traffic.LiveTrafficQuerier, h traffic.HistoricalSpeedQuerier) (*Model
 		return nil, trafficapplyingmodel.ErrNoValidTrafficQuerier
 	}
 
-	appendOnly, err := appendonly.New(l, h)
+	appendOnly, err := appendspeedonly.New(l, h)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/service/ranking/trafficapplyingmodel/preferlivetraffic/model.go
+++ b/integration/service/ranking/trafficapplyingmodel/preferlivetraffic/model.go
@@ -1,0 +1,197 @@
+// Package preferlivetraffic prefers to apply live traffic as much as possible, otherwise applys historical speed for no live traffic ways.
+// Both live traffic and historical speed will be appended to annotations on a OSRM route, same as what package appendonly provides.
+package preferlivetraffic
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/Telenav/osrm-backend/integration/traffic/livetraffic/trafficproxy"
+
+	"github.com/Telenav/osrm-backend/integration/pkg/api/osrm/route"
+	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel"
+	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel/appendonly"
+	"github.com/Telenav/osrm-backend/integration/traffic"
+	"github.com/golang/glog"
+)
+
+// Name represents the name of traffic applying model.
+func Name() string {
+	return "prefer-live-traffic"
+}
+
+// Model represents the model of applying traffic.
+type Model struct {
+	traffic.LiveTrafficQuerier
+	traffic.HistoricalSpeedQuerier
+
+	appendOnly *appendonly.Model
+}
+
+// New creates a new model object.
+func New(l traffic.LiveTrafficQuerier, h traffic.HistoricalSpeedQuerier) (*Model, error) {
+	if l == nil && h == nil {
+		return nil, trafficapplyingmodel.ErrNoValidTrafficQuerier
+	}
+
+	appendOnly, err := appendonly.New(l, h)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Model{l, h, appendOnly}, nil
+}
+
+// ApplyTraffic applys traffic on a route.
+func (m Model) ApplyTraffic(r *route.Route, liveTraffic bool, historicalSpeed bool) error {
+	if r == nil {
+		return trafficapplyingmodel.ErrEmptyRoute
+	}
+	if m.LiveTrafficQuerier == nil && m.HistoricalSpeedQuerier == nil {
+		return trafficapplyingmodel.ErrNoValidTrafficQuerier
+	}
+	if !liveTraffic && !historicalSpeed {
+		return nil // nothing need to do
+	}
+
+	// firstly append traffic at current clock
+	if err := m.appendOnly.ApplyTraffic(r, liveTraffic, historicalSpeed); err != nil {
+		return err
+	}
+
+	// calculate by traffic: prefer live traffic if exist, other historical speed if exist
+	var newRouteDuration, newRouteWeight float64
+	for _, l := range r.Legs {
+		if err := m.recalcOnLeg(l, liveTraffic, historicalSpeed); err != nil {
+			return err
+		}
+		if math.IsInf(l.Duration, 0) || math.IsInf(l.Weight, 0) {
+			glog.Warningf("route blocked by live traffic, set duration to infinity")
+			r.Duration = l.Duration
+			r.Weight = l.Weight
+			return nil
+		}
+		newRouteDuration += l.Duration
+		newRouteWeight += l.Weight
+	}
+	glog.V(1).Infof("route applied traffic, duration,weight %f,%f -> %f,%f (reduced %f,%f)",
+		r.Duration, r.Weight, newRouteDuration, newRouteWeight, r.Duration-newRouteDuration, r.Weight-newRouteWeight)
+	r.Duration = newRouteDuration
+	r.Weight = newRouteWeight
+	return nil
+}
+
+func (m Model) recalcOnLeg(l *route.Leg, enableLiveTraffic bool, enableHistoricalSpeed bool) error {
+	if l == nil {
+		return trafficapplyingmodel.ErrEmptyLeg
+	}
+	if l.Annotation == nil {
+		return trafficapplyingmodel.ErrEmptyAnnotation
+	}
+	if l.Annotation.Metadata == nil {
+		return trafficapplyingmodel.ErrEmptyAnnotationMetadata
+	}
+
+	// data validating
+	waysCount := len(l.Annotation.Ways)
+	if len(l.Annotation.Distance) != waysCount ||
+		len(l.Annotation.Duration) != waysCount ||
+		len(l.Annotation.Speed) != waysCount ||
+		len(l.Annotation.Weight) != waysCount ||
+		len(l.Annotation.DataSources) != waysCount {
+		return fmt.Errorf("annotation data not match: ways,distance,duration,speed,weight,datasources %d,%d,%d,%d,%d,%d",
+			waysCount, len(l.Annotation.Distance), len(l.Annotation.Duration), len(l.Annotation.Speed), len(l.Annotation.Weight), len(l.Annotation.DataSources))
+	}
+	if m.LiveTrafficQuerier != nil && enableLiveTraffic { // requires live traffic data
+		if len(l.Annotation.LiveTrafficLevel) != waysCount ||
+			len(l.Annotation.LiveTrafficSpeed) != waysCount ||
+			len(l.Annotation.BlockIncident) != waysCount {
+			return fmt.Errorf("annotation live traffic data not match: ways,live_traffic_level,live_traffic_speed,block_incident %d,%d,%d,%d",
+				waysCount, len(l.Annotation.LiveTrafficLevel), len(l.Annotation.LiveTrafficSpeed), len(l.Annotation.BlockIncident))
+		}
+	}
+	if m.HistoricalSpeedQuerier != nil && enableHistoricalSpeed { // requires historical speed data
+		if len(l.Annotation.HistoricalSpeed) != waysCount {
+			return fmt.Errorf("annotation historical speed data not match: ways,historical_speed %d,%d", waysCount, len(l.Annotation.HistoricalSpeed))
+		}
+	}
+
+	// set data source index
+	var liveTrafficSourceNameIndex, historicalSpeedSourceNameIndex int
+	if m.HistoricalSpeedQuerier != nil && enableHistoricalSpeed { // requires historical speed data
+		historicalSpeedSourceNameIndex = len(l.Annotation.Metadata.DataSourceNames)
+		l.Annotation.Metadata.DataSourceNames = append(l.Annotation.Metadata.DataSourceNames, trafficapplyingmodel.SourceNameHistoricalSpeed)
+	}
+	if m.LiveTrafficQuerier != nil && enableLiveTraffic { // requires live traffic data
+		liveTrafficSourceNameIndex = len(l.Annotation.Metadata.DataSourceNames)
+		l.Annotation.Metadata.DataSourceNames = append(l.Annotation.Metadata.DataSourceNames, trafficapplyingmodel.SourceNameLiveTraffic)
+	}
+
+	// recalc
+	var sumOriginalAnnotationDuration, sumOriginalAnnotationDistance, sumOriginalAnnotationWeight float64
+	var newLegDuration, newLegWeight float64
+	var appliedHistoricalSpeedCount, appliedLiveTrafficSpeedCount int
+	for i := 0; i < waysCount; i++ {
+		wayID := l.Annotation.Ways[i]
+
+		sumOriginalAnnotationDistance += l.Annotation.Distance[i]
+		sumOriginalAnnotationDuration += l.Annotation.Duration[i]
+		sumOriginalAnnotationWeight += l.Annotation.Weight[i]
+
+		if m.HistoricalSpeedQuerier != nil && enableHistoricalSpeed {
+			if !trafficapplyingmodel.IsInvalidSpeed(l.Annotation.HistoricalSpeed[i]) { // valid historical speed
+				l.Annotation.DataSources[i] = historicalSpeedSourceNameIndex
+				l.Annotation.Speed[i] = l.Annotation.HistoricalSpeed[i]
+				l.Annotation.Duration[i] = l.Annotation.Distance[i] / l.Annotation.Speed[i] // not include turn duration
+				l.Annotation.Weight[i] = l.Annotation.Distance[i] / l.Annotation.Speed[i]   // not include turn weight
+			}
+		}
+		if m.LiveTrafficQuerier != nil && enableLiveTraffic {
+			if l.Annotation.BlockIncident[i] {
+				glog.Warningf("way %d on leg blocked by incident, set duration to infinity", wayID)
+				l.Duration = math.Inf(0)
+				l.Weight = math.Inf(0)
+				return nil
+			}
+			if trafficproxy.TrafficLevel(l.Annotation.LiveTrafficLevel[i]) == trafficproxy.TrafficLevel_CLOSED {
+				glog.Warningf("way %d on leg blocked by CLOSED flow, set duration to infinity", wayID)
+				l.Duration = math.Inf(0)
+				l.Weight = math.Inf(0)
+				return nil
+			}
+
+			if !trafficapplyingmodel.IsInvalidSpeed(l.Annotation.LiveTrafficSpeed[i]) { // valid live traffic speed
+				l.Annotation.DataSources[i] = liveTrafficSourceNameIndex
+				l.Annotation.Speed[i] = l.Annotation.LiveTrafficSpeed[i]
+				l.Annotation.Duration[i] = l.Annotation.Distance[i] / l.Annotation.Speed[i] // not include turn duration
+				l.Annotation.Weight[i] = l.Annotation.Distance[i] / l.Annotation.Speed[i]   // not include turn weight
+			}
+		}
+
+		newLegDuration += l.Annotation.Duration[i]
+		newLegWeight += l.Annotation.Weight[i]
+		if l.Annotation.DataSources[i] == liveTrafficSourceNameIndex {
+			appliedLiveTrafficSpeedCount++
+		}
+		if l.Annotation.DataSources[i] == historicalSpeedSourceNameIndex {
+			appliedHistoricalSpeedCount++
+		}
+	}
+	// metioned in doc, duration and weight in annotation does not include any on turn, so we calculate turn duration/weight by minus.
+	// https://github.com/Telenav/osrm-backend/blob/master-telenav/docs/http.md#annotation-object
+	legTurnDuration := l.Duration - sumOriginalAnnotationDuration
+	legTurnWeight := l.Weight - sumOriginalAnnotationWeight
+	newLegDuration += legTurnDuration
+	newLegWeight += legTurnWeight
+	glog.V(2).Infof("leg ways count %d, applied %s %d, appiled %s %d, leg distance %f(%f sum by annotation), duration,weight %f,%f(%f,%f sum by annotation, %f,%f on turn) -> %f,%f (reduced %f,%f)",
+		waysCount, trafficapplyingmodel.SourceNameLiveTraffic, appliedLiveTrafficSpeedCount, trafficapplyingmodel.SourceNameHistoricalSpeed, appliedHistoricalSpeedCount,
+		l.Distance, sumOriginalAnnotationDistance,
+		l.Duration, l.Weight, sumOriginalAnnotationDuration, sumOriginalAnnotationWeight, legTurnDuration, legTurnWeight, newLegDuration, newLegWeight, l.Duration-newLegDuration, l.Weight-newLegWeight)
+
+	if appliedLiveTrafficSpeedCount > 0 || appliedHistoricalSpeedCount > 0 {
+		l.Duration = newLegDuration
+		l.Weight = newLegWeight
+	}
+
+	return nil
+}

--- a/integration/service/ranking/trafficapplyingmodel/preferlivetraffic/model.go
+++ b/integration/service/ranking/trafficapplyingmodel/preferlivetraffic/model.go
@@ -1,4 +1,4 @@
-// Package preferlivetraffic prefers to apply live traffic as much as possible, otherwise applys historical speed for no live traffic ways.
+// Package preferlivetraffic re-calculate duration/weight for a route, prefer to use live traffic, if no live traffic on a way then use historical speed, otherwise use the speed from Lua profile.
 // Both live traffic and historical speed will be appended to annotations on a OSRM route, same as what package appendonly provides.
 package preferlivetraffic
 

--- a/integration/service/ranking/trafficapplyingmodel/traffic_source_name.go
+++ b/integration/service/ranking/trafficapplyingmodel/traffic_source_name.go
@@ -1,0 +1,7 @@
+package trafficapplyingmodel
+
+// Represent speeds source name.
+const (
+	SourceNameHistoricalSpeed = "historical speed"
+	SourceNameLiveTraffic     = "live traffic"
+)

--- a/integration/service/ranking/update_by_traffic.go
+++ b/integration/service/ranking/update_by_traffic.go
@@ -2,15 +2,16 @@ package ranking
 
 import (
 	"math"
+	"strconv"
 
 	"github.com/Telenav/osrm-backend/integration/pkg/api/osrm/route"
 )
 
-func (h *Handler) updateRoutesByTraffic(routes []*route.Route) ([]*route.Route, error) {
+func (h *Handler) updateRoutesByTraffic(routes []*route.Route, enableLiveTraffic, enableHistoricalSpeed bool) ([]*route.Route, error) {
 	updatedRoutes := []*route.Route{}
 	for _, r := range routes {
 
-		if err := h.trafficApplier.ApplyTraffic(r, true, true); err != nil {
+		if err := h.trafficApplier.ApplyTraffic(r, enableLiveTraffic, enableHistoricalSpeed); err != nil {
 			return nil, err
 		}
 		if math.IsInf(r.Duration, 0) || math.IsInf(r.Weight, 0) {
@@ -20,3 +21,22 @@ func (h *Handler) updateRoutesByTraffic(routes []*route.Route) ([]*route.Route, 
 	}
 	return updatedRoutes, nil
 }
+
+func parseTrafficOptions(liveTrafficQueryValue, historicalSpeedQueryValue string) (bool, bool) {
+	var enableLiveTraffic, enableHistoricalSpeed bool // both false by default
+	if b, err := strconv.ParseBool(liveTrafficQueryValue); err == nil {
+		enableLiveTraffic = b
+	}
+	if b, err := strconv.ParseBool(historicalSpeedQueryValue); err == nil {
+		enableHistoricalSpeed = b
+	}
+	return enableLiveTraffic, enableHistoricalSpeed
+}
+
+const (
+	// NOTE: These two are route request keys, but they're not OSRM original keys.
+	// We keep them here to reduce impacts but provides flexibility to support these options on the fly.
+	// Consider to move them into OSRM API when really necessary.
+	liveTrafficQueryKey     = "live_traffic"
+	historicalSpeedQueryKey = "historical_speed"
+)

--- a/integration/service/ranking/update_by_traffic.go
+++ b/integration/service/ranking/update_by_traffic.go
@@ -4,109 +4,19 @@ import (
 	"math"
 
 	"github.com/Telenav/osrm-backend/integration/pkg/api/osrm/route"
-	"github.com/golang/glog"
 )
 
-func (h *Handler) updateRoutesByTraffic(routes []*route.Route) []*route.Route {
+func (h *Handler) updateRoutesByTraffic(routes []*route.Route) ([]*route.Route, error) {
 	updatedRoutes := []*route.Route{}
 	for _, r := range routes {
-		h.updateRouteByTraffic(r)
+
+		if err := h.trafficApplier.ApplyTraffic(r, true, true); err != nil {
+			return nil, err
+		}
 		if math.IsInf(r.Duration, 0) || math.IsInf(r.Weight, 0) {
-			continue // ignore the route
+			continue // discard the route
 		}
 		updatedRoutes = append(updatedRoutes, r)
 	}
-	return updatedRoutes
-}
-
-func (h *Handler) updateRouteByTraffic(route *route.Route) {
-	if route == nil {
-		glog.Error("empty route")
-		return
-	}
-
-	var newRouteDuration, newRouteWeight float64
-	for _, l := range route.Legs {
-		h.updateLegByTraffic(l)
-		if math.IsInf(l.Duration, 0) || math.IsInf(l.Weight, 0) {
-			glog.Warningf("route blocked by live traffic, set duration to infinity")
-			route.Duration = l.Duration
-			route.Weight = l.Weight
-			return
-		}
-		newRouteDuration += l.Duration
-		newRouteWeight += l.Weight
-	}
-	glog.V(1).Infof("route update by traffic, duration,weight %f,%f -> %f,%f (reduced %f,%f)",
-		route.Duration, route.Weight, newRouteDuration, newRouteWeight, route.Duration-newRouteDuration, route.Weight-newRouteWeight)
-	route.Duration = newRouteDuration
-	route.Weight = newRouteWeight
-}
-
-func (h *Handler) updateLegByTraffic(leg *route.Leg) {
-	if leg == nil {
-		glog.Error("empty leg")
-		return
-	}
-	waysCount := len(leg.Annotation.Ways)
-	if len(leg.Annotation.Distance) != waysCount ||
-		len(leg.Annotation.Duration) != waysCount ||
-		len(leg.Annotation.Speed) != waysCount ||
-		len(leg.Annotation.Weight) != waysCount ||
-		len(leg.Annotation.DataSources) != waysCount {
-		glog.Errorf("annotation counts not match")
-		return
-	}
-
-	validFlowsCount := 0
-	trafficDataSourceNameIndex := len(leg.Annotation.Metadata.DataSourceNames)
-	var sumOriginalAnnotationDuration, sumOriginalAnnotationDistance, sumOriginalAnnotationWeight float64
-	var newLegDuration, newLegWeight float64
-	for i := 0; i < waysCount; i++ {
-		sumOriginalAnnotationDistance += leg.Annotation.Distance[i]
-		sumOriginalAnnotationDuration += leg.Annotation.Duration[i]
-		sumOriginalAnnotationWeight += leg.Annotation.Weight[i]
-
-		wayID := leg.Annotation.Ways[i]
-
-		if h.trafficQuerier.BlockedByIncident(wayID) {
-			glog.Warningf("way %d on leg blocked by incident, set duration to infinity", wayID)
-			leg.Duration = math.Inf(0)
-			leg.Weight = math.Inf(0)
-			return
-		}
-
-		flow := h.trafficQuerier.QueryFlow(wayID)
-		if flow != nil {
-			if flow.IsBlocking() {
-				glog.Warningf("way %d on leg blocked by flow %v, set duration to infinity", wayID, flow)
-				leg.Duration = math.Inf(0)
-				leg.Weight = math.Inf(0)
-				return // exit the update once found blocking flow
-			}
-
-			validFlowsCount++
-			leg.Annotation.DataSources[i] = trafficDataSourceNameIndex
-			leg.Annotation.Speed[i] = float64(flow.Speed)
-			leg.Annotation.Duration[i] = leg.Annotation.Distance[i] / leg.Annotation.Speed[i] // not include turn duration
-			leg.Annotation.Weight[i] = leg.Annotation.Distance[i] / leg.Annotation.Speed[i]   // not include turn weight
-		}
-		newLegDuration += leg.Annotation.Duration[i]
-		newLegWeight += leg.Annotation.Weight[i]
-	}
-	// metioned in doc, duration and weight in annotation does not include any on turn, so we calculate turn duration/weight by minus.
-	// https://github.com/Telenav/osrm-backend/blob/master-telenav/docs/http.md#annotation-object
-	legTurnDuration := leg.Duration - sumOriginalAnnotationDuration
-	legTurnWeight := leg.Weight - sumOriginalAnnotationWeight
-	newLegDuration += legTurnDuration
-	newLegWeight += legTurnWeight
-	glog.V(2).Infof("leg ways count %d, leg distance %f(%f sum by annotation), valid flows count %d, duration,weight %f,%f(%f,%f sum by annotation, %f,%f on turn) -> %f,%f (reduced %f,%f)",
-		waysCount, leg.Distance, sumOriginalAnnotationDistance, validFlowsCount,
-		leg.Duration, leg.Weight, sumOriginalAnnotationDuration, sumOriginalAnnotationWeight, legTurnDuration, legTurnWeight, newLegDuration, newLegWeight, leg.Duration-newLegDuration, leg.Weight-newLegWeight)
-
-	if validFlowsCount > 0 {
-		leg.Annotation.Metadata.DataSourceNames = append(leg.Annotation.Metadata.DataSourceNames, "live traffic")
-		leg.Duration = newLegDuration
-		leg.Weight = newLegWeight
-	}
+	return updatedRoutes, nil
 }


### PR DESCRIPTION
# Issue

- Targeting issue: the issue will be CLOSED once the PR merged. If there is no issue that addresses the problem, please open a corresponding issue and link it here. Uses the [Closes keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close them automatically.     
Closes https://github.com/Telenav/osrm-backend/issues/221

- Any other related issue? Mention them here.    

## Description    
A summary description for what the PR achieves.           

- Implemented two traffic applying models:     
  - appendonly: only querys traffic and append to OSRM response, no any re-calcualation 
  - perferlivetraffic: prefer to use live traffic to re-calculate duration/weight on a route, use historical speed if no live traffic on a way, otherwise use the speed from Lua profile 
- Support to choose traffic applying model when startup `osrm-ranking` by cmd parameter `-traffic-applying-model`;    
- Support to enable/disable live traffic and historical speed on the fly(by request parameters: `live_traffic=true/false`, `historical_speed=true/false`;    
- Support to enable/disable live traffic when startup `osrm-ranking` by cmd parameter `-live-traffic`;    
- Renamed historical speed cmd parameters for `osrm-ranking`.        

## Tasklist

 - [x] CHANGELOG-FORK.md entry ([CHANGELOG](https://github.com/Telenav/osrm-backend/wiki/CHANGELOG))
 - [ ] [profiles/CHANGELOG.md](https://github.com/Telenav/osrm-backend/blob/master/profiles/CHANGELOG.md) entry if any `Lua` changes   
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)


## Prerequirements
- Want to contribute? Great! First, please read this page [Contribution Guidelines](https://github.com/Telenav/osrm-backend/wiki/Contribution-Guidelines).    
- If your PR is still work in progress please attach the relevant label.    
