### PR TITLE
Fix wrong variable in `docker-entrypoint.sh`

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -8,6 +8,7 @@ Changes from v10.2.0
   - REMOVED edge indexed live traffic cache in `osrm-ranking` [#308](https://github.com/Telenav/osrm-backend/pull/308)
 - Bugfix:    
   - CHANGED `osrm-ranking` parsing of OSRM route response to compatible with `string` array `annotation/nodes` [#296](https://github.com/Telenav/osrm-backend/pull/296)     
+  - FIXED wrong variable `docker-entrypoint.sh` [#311](https://github.com/Telenav/osrm-backend/pull/311)
 - Performance:    
 - Tools:    
   - ADDED `merge=union` for resolving merge conflicits automatically on `CHANGELOG-FORK.md` [#305](https://github.com/Telenav/osrm-backend/pull/305)

--- a/docker-orchestration/osrm-backend/docker-entrypoint.sh
+++ b/docker-orchestration/osrm-backend/docker-entrypoint.sh
@@ -29,7 +29,7 @@ if [ "$1" = 'routed_startup' ] || [ "$1" = 'routed_blocking_traffic_startup' ]; 
   fi
 
   cd ${DATA_PATH}
-  ${BUILD_PATH}/osrm-traffic-updater -c ${TRAFFIC_PROXY_IP} -m ${WAYID2NODEIDS_MAPPING_FILE_COMPRESSED} -f ${TRAFFIC_FILE} -map ${MAP_PROVIDER} -traffic ${TRAFFIC_PROVIDER} -region ${REGION} ${BLOCKING_ONLY}
+  ${BUILD_PATH}/osrm-traffic-updater -c ${TRAFFIC_PROXY_IP} -m ${WAYID2NODEIDS_MAPPING_FILE}${SNAPPY_SUFFIX} -f ${TRAFFIC_FILE} -map ${MAP_PROVIDER} -traffic ${TRAFFIC_PROVIDER} -region ${REGION} ${BLOCKING_ONLY}
   ls -lh
   ${BUILD_PATH}/osrm-customize ${MAPDATA_NAME_WITH_SUFFIX}.osrm  --segment-speed-file ${TRAFFIC_FILE} ${OSRM_EXTRA_COMMAND} ${INCREMENTAL_CUSTOMIZE}
   ${BUILD_PATH}/osrm-routed ${MAPDATA_NAME_WITH_SUFFIX}.osrm ${OSRM_ROUTED_STARTUP_COMMAND} &


### PR DESCRIPTION
# Issue

- Targeting issue: the issue will be CLOSED once the PR merged. If there is no issue that addresses the problem, please open a corresponding issue and link it here. Uses the [Closes keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close them automatically.     
Closes https://github.com/Telenav/osrm-backend/issues/309

- Any other related issue? Mention them here.    

## Description    
A summary description for what the PR achieves.           

- Fix wrong variable in `docker-entrypoint.sh`

## Tasklist

 - [x] CHANGELOG-FORK.md entry ([CHANGELOG](https://github.com/Telenav/osrm-backend/wiki/CHANGELOG))
 - [ ] [profiles/CHANGELOG.md](https://github.com/Telenav/osrm-backend/blob/master/profiles/CHANGELOG.md) entry if any `Lua` changes   
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)


## Prerequirements
- Want to contribute? Great! First, please read this page [Contribution Guidelines](https://github.com/Telenav/osrm-backend/wiki/Contribution-Guidelines).    
- If your PR is still work in progress please attach the relevant label.    
