### PR TITLE
Auto compile sample data

### DIFF
--- a/.github/workflows/autobuild-osrm-backend.yml
+++ b/.github/workflows/autobuild-osrm-backend.yml
@@ -66,12 +66,12 @@ jobs:
         uses: managedkaos/print-env@v1.0
 
       - name: pull built image
-        run: docker pull "${{ env.DOCKERHUB_REGISTRY }}/${{ env.OSRM_BACKEND_WITHIN_MAPDATA_IMAGE_NAME }}:${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}"
+        run: docker pull "${{ env.DOCKERHUB_REGISTRY }}/${{ env.OSRM_BACKEND_IMAGE_NAME }}:${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}"
       - name: Checkout
         uses: actions/checkout@v2
       - name: Compile data
         run: |
-          cd ${{ env.OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH }} && docker run --mount "src=$(pwd)/${{ env.COMPILED_DATA_PATH }},dst=/compiled-data,type=bind" "${{ env.DOCKERHUB_REGISTRY }}/${{ env.OSRM_BACKEND_WITHIN_MAPDATA_IMAGE_NAME }}:${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}" compile_mapdata "${{ env.SAMPLE_PROFILE }}" "${{ env.SAMPLE_OSM_MAPDATA }}" 
+          cd ${{ env.OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH }} && docker run --mount "src=$(pwd)/${{ env.COMPILED_DATA_PATH }},dst=/compiled-data,type=bind" "${{ env.DOCKERHUB_REGISTRY }}/${{ env.OSRM_BACKEND_IMAGE_NAME }}:${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}" compile_mapdata "${{ env.SAMPLE_PROFILE }}" "${{ env.SAMPLE_OSM_MAPDATA }}" 
       - name: Build & Publish osrm-backend-within-mapdata to DockerHub
         uses: elgohr/Publish-Docker-Github-Action@master
         with:

--- a/.github/workflows/autobuild-osrm-backend.yml
+++ b/.github/workflows/autobuild-osrm-backend.yml
@@ -51,12 +51,40 @@ jobs:
     name: Compile map data
     runs-on: ubuntu-latest
     needs: build
-
+    env:
+      BUILT_OSRM_BACKEND_IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
+      COMPILED_DATA_PATH: mapdata
+      OSRM_BACKEND_WITHIN_MAPDATA_IMAGE_NAME: osrm-backend-within-mapdata
+      OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH: docker-orchestration/osrm-backend/
+      SAMPLE_PROFILE: profiles/car.lua
+      SAMPLE_OSM_MAPDATA: https://download.geofabrik.de/north-america/us/nevada-latest.osm.pbf
     steps: 
+      - name: Set DATA_IMAGE_TAG env
+        run: echo ::set-env name=DATA_IMAGE_TAG::$(echo ${BUILT_OSRM_BACKEND_IMAGE_TAG} )-$(basename ${SAMPLE_OSM_MAPDATA%.osm.pbf})
+      - name: Comma-separated image tags 
+        run: echo ::set-env name=COMMA_SEPARATED_DATA_IMAGE_TAGS::${DATA_IMAGE_TAG}
+      - name: Append latest if on master branch # env '${IMAGE_TAG},latest'
+        if: endsWith(github.ref, 'master')
+        run: echo ::set-env name=COMMA_SEPARATED_DATA_IMAGE_TAGS::${COMMA_SEPARATED_DATA_IMAGE_TAGS},latest
+      - name: Environment Printer
+        uses: managedkaos/print-env@v1.0
+
       - name: pull built image
-        run: docker pull "${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.image-tag }}"
+        run: docker pull "${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}"
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Compile data
         run: |
-          docker run "${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.image-tag }}" compile_mapdata "profiles/car.lua" "https://download.geofabrik.de/north-america/us/nevada-latest.osm.pbf" 
-
+          cd ${{ env.OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH }} && docker run --mount "src=$(pwd)/${{ env.COMPILED_DATA_PATH }},dst=/compiled-data,type=bind" "${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.image-tag }}" compile_mapdata "${{ env.SAMPLE_PROFILE }}" "${{ env.SAMPLE_OSM_MAPDATA }}" 
+      - name: Build & Publish osrm-backend-within-mapdata to DockerHub
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.OSRM_BACKEND_WITHIN_MAPDATA_IMAGE_NAME }}
+          username: ${{ secrets.TELENAVMAP_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.TELENAVMAP_DOCKERHUB_TOKEN }}
+          snapshot: false
+          workdir: ${{ env.OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH }}
+          tags: "${{ env.COMMA_SEPARATED_DATA_IMAGE_TAGS }}"
+          buildargs: "FROM_TAG=${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}"
+    
 

--- a/.github/workflows/autobuild-osrm-backend.yml
+++ b/.github/workflows/autobuild-osrm-backend.yml
@@ -4,16 +4,6 @@ on:
   push:
     branches:
     - '**'
-    paths:
-    - 'cmake/**'
-    - 'docker-orchestration/osrm-backend/**'
-    - 'fuzz/**'
-    - 'include/**'
-    - 'integration/**'
-    - 'profiles/**'
-    - 'src/**'
-    - 'third_party/**'
-    - 'unit_tests/**'
 
 env:
   IMAGE_NAME: osrm-backend

--- a/.github/workflows/autobuild-osrm-backend.yml
+++ b/.github/workflows/autobuild-osrm-backend.yml
@@ -13,14 +13,18 @@ env:
 jobs:
 
   build:
-
+    name: Build osrm-backend docker
     runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.step-output-image-tag.outputs.output_var }}
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set IMAGE_TAG env # env IMAGE_TAG=BranchName-CommitID-Timestamp
       run: echo ::set-env name=IMAGE_TAG::$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev )-$(echo ${GITHUB_SHA} | cut -c 1-7)-$(date -u +"%Y%m%d")
+    - id: step-output-image-tag
+      run: echo "::set-output name=output_var::${{ env.IMAGE_TAG }}"
     - name: Environment Printer
       uses: managedkaos/print-env@v1.0
       
@@ -42,4 +46,17 @@ jobs:
         workdir: ${{ env.DOCKERFILE_PATH }}
         tags: "${{ env.COMMA_SEPARATED_IMAGE_TAGS }}"
         buildargs: "GIT_COMMIT=${{ github.sha }},IMAGE_TAG=${{ env.IMAGE_TAG }}"
+
+  compile-data:
+    name: Compile map data
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps: 
+      - name: pull built image
+        run: docker pull "${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.image-tag }}"
+      - name: Compile data
+        run: |
+          docker run "${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.image-tag }}" compile_mapdata "profiles/car.lua" "https://download.geofabrik.de/north-america/us/nevada-latest.osm.pbf" 
+
 

--- a/.github/workflows/autobuild-osrm-backend.yml
+++ b/.github/workflows/autobuild-osrm-backend.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches:
     - '**'
+    paths:
+    - 'cmake/**'
+    - 'docker-orchestration/osrm-backend/**'
+    - 'fuzz/**'
+    - 'include/**'
+    - 'integration/**'
+    - 'profiles/**'
+    - 'src/**'
+    - 'third_party/**'
+    - 'unit_tests/**'
 
 env:
   DOCKERHUB_REGISTRY: telenavmap

--- a/.github/workflows/autobuild-osrm-backend.yml
+++ b/.github/workflows/autobuild-osrm-backend.yml
@@ -6,9 +6,12 @@ on:
     - '**'
 
 env:
-  IMAGE_NAME: osrm-backend
-  DOCKERFILE_PATH: docker-orchestration/osrm-backend/
   DOCKERHUB_REGISTRY: telenavmap
+
+  OSRM_BACKEND_IMAGE_NAME: osrm-backend
+  OSRM_BACKEND_DOCKERFILE_PATH: docker-orchestration/osrm-backend/
+  OSRM_BACKEND_WITHIN_MAPDATA_IMAGE_NAME: osrm-backend-within-mapdata
+  OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH: docker-orchestration/osrm-backend-within-mapdata/
 
 jobs:
 
@@ -17,17 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.step-output-image-tag.outputs.output_var }}
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set IMAGE_TAG env # env IMAGE_TAG=BranchName-CommitID-Timestamp
       run: echo ::set-env name=IMAGE_TAG::$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev )-$(echo ${GITHUB_SHA} | cut -c 1-7)-$(date -u +"%Y%m%d")
     - id: step-output-image-tag
-      run: echo "::set-output name=output_var::${{ env.IMAGE_TAG }}"
-    - name: Environment Printer
-      uses: managedkaos/print-env@v1.0
-      
+      run: echo "::set-output name=output_var::${{ env.IMAGE_TAG }}"      
     - name: Comma-separated image tags 
       run: echo ::set-env name=COMMA_SEPARATED_IMAGE_TAGS::${IMAGE_TAG}
     - name: Append latest if on master branch # env '${IMAGE_TAG},latest'
@@ -35,15 +34,14 @@ jobs:
       run: echo ::set-env name=COMMA_SEPARATED_IMAGE_TAGS::${COMMA_SEPARATED_IMAGE_TAGS},latest
     - name: Environment Printer
       uses: managedkaos/print-env@v1.0
-
     - name: Build & Publish to DockerHub
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}
+        name: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.OSRM_BACKEND_IMAGE_NAME }}
         username: ${{ secrets.TELENAVMAP_DOCKERHUB_USERNAME }}
         password: ${{ secrets.TELENAVMAP_DOCKERHUB_TOKEN }}
         snapshot: false
-        workdir: ${{ env.DOCKERFILE_PATH }}
+        workdir: ${{ env.OSRM_BACKEND_DOCKERFILE_PATH }}
         tags: "${{ env.COMMA_SEPARATED_IMAGE_TAGS }}"
         buildargs: "GIT_COMMIT=${{ github.sha }},IMAGE_TAG=${{ env.IMAGE_TAG }}"
 
@@ -54,8 +52,6 @@ jobs:
     env:
       BUILT_OSRM_BACKEND_IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
       COMPILED_DATA_PATH: mapdata
-      OSRM_BACKEND_WITHIN_MAPDATA_IMAGE_NAME: osrm-backend-within-mapdata
-      OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH: docker-orchestration/osrm-backend/
       SAMPLE_PROFILE: profiles/car.lua
       SAMPLE_OSM_MAPDATA: https://download.geofabrik.de/north-america/us/nevada-latest.osm.pbf
     steps: 
@@ -75,7 +71,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Compile data
         run: |
-          cd ${{ env.OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH }} && docker run --mount "src=$(pwd)/${{ env.COMPILED_DATA_PATH }},dst=/compiled-data,type=bind" "${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build.outputs.image-tag }}" compile_mapdata "${{ env.SAMPLE_PROFILE }}" "${{ env.SAMPLE_OSM_MAPDATA }}" 
+          cd ${{ env.OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH }} && docker run --mount "src=$(pwd)/${{ env.COMPILED_DATA_PATH }},dst=/compiled-data,type=bind" "${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}" compile_mapdata "${{ env.SAMPLE_PROFILE }}" "${{ env.SAMPLE_OSM_MAPDATA }}" 
       - name: Build & Publish osrm-backend-within-mapdata to DockerHub
         uses: elgohr/Publish-Docker-Github-Action@master
         with:

--- a/.github/workflows/autobuild-osrm-backend.yml
+++ b/.github/workflows/autobuild-osrm-backend.yml
@@ -51,7 +51,7 @@ jobs:
     needs: build
     env:
       BUILT_OSRM_BACKEND_IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
-      COMPILED_DATA_PATH: mapdata
+      COMPILED_DATA_PATH: map
       SAMPLE_PROFILE: profiles/car.lua
       SAMPLE_OSM_MAPDATA: https://download.geofabrik.de/north-america/us/nevada-latest.osm.pbf
     steps: 
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Compile data
         run: |
-          cd ${{ env.OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH }} && docker run --mount "src=$(pwd)/${{ env.COMPILED_DATA_PATH }},dst=/compiled-data,type=bind" "${{ env.DOCKERHUB_REGISTRY }}/${{ env.OSRM_BACKEND_IMAGE_NAME }}:${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}" compile_mapdata "${{ env.SAMPLE_PROFILE }}" "${{ env.SAMPLE_OSM_MAPDATA }}" 
+          cd ${{ env.OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH }} && mkdir -p ${{ env.COMPILED_DATA_PATH }} && docker run --mount "src=$(pwd)/${{ env.COMPILED_DATA_PATH }},dst=/compiled-data,type=bind" "${{ env.DOCKERHUB_REGISTRY }}/${{ env.OSRM_BACKEND_IMAGE_NAME }}:${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}" compile_mapdata "${{ env.SAMPLE_PROFILE }}" "${{ env.SAMPLE_OSM_MAPDATA }}" 
       - name: Build & Publish osrm-backend-within-mapdata to DockerHub
         uses: elgohr/Publish-Docker-Github-Action@master
         with:

--- a/.github/workflows/autobuild-osrm-backend.yml
+++ b/.github/workflows/autobuild-osrm-backend.yml
@@ -66,12 +66,12 @@ jobs:
         uses: managedkaos/print-env@v1.0
 
       - name: pull built image
-        run: docker pull "${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}"
+        run: docker pull "${{ env.DOCKERHUB_REGISTRY }}/${{ env.OSRM_BACKEND_WITHIN_MAPDATA_IMAGE_NAME }}:${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}"
       - name: Checkout
         uses: actions/checkout@v2
       - name: Compile data
         run: |
-          cd ${{ env.OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH }} && docker run --mount "src=$(pwd)/${{ env.COMPILED_DATA_PATH }},dst=/compiled-data,type=bind" "${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}" compile_mapdata "${{ env.SAMPLE_PROFILE }}" "${{ env.SAMPLE_OSM_MAPDATA }}" 
+          cd ${{ env.OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH }} && docker run --mount "src=$(pwd)/${{ env.COMPILED_DATA_PATH }},dst=/compiled-data,type=bind" "${{ env.DOCKERHUB_REGISTRY }}/${{ env.OSRM_BACKEND_WITHIN_MAPDATA_IMAGE_NAME }}:${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}" compile_mapdata "${{ env.SAMPLE_PROFILE }}" "${{ env.SAMPLE_OSM_MAPDATA }}" 
       - name: Build & Publish osrm-backend-within-mapdata to DockerHub
         uses: elgohr/Publish-Docker-Github-Action@master
         with:

--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -11,6 +11,7 @@ Changes from v10.2.0
 - Performance:    
 - Tools:    
   - ADDED `merge=union` for resolving merge conflicits automatically on `CHANGELOG-FORK.md` [#305](https://github.com/Telenav/osrm-backend/pull/305)
+  - ADDED automatically data compiliation and publish `telenavmap/osrm-backend-within-mapdata` [#313](https://github.com/Telenav/osrm-backend/pull/313)
 - Docs:    
 
 


### PR DESCRIPTION
# Issue

- Targeting issue: the issue will be CLOSED once the PR merged. If there is no issue that addresses the problem, please open a corresponding issue and link it here. Uses the [Closes keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close them automatically.     
Closes https://github.com/Telenav/osrm-backend/issues/312

- Any other related issue? Mention them here.    

## Description    
A summary description for what the PR achieves.           

- Automatically compile latest sample data and publish `telenavmap/osrm-backend-within-mapdata` docker.     

## Tasklist

 - [x] CHANGELOG-FORK.md entry ([CHANGELOG](https://github.com/Telenav/osrm-backend/wiki/CHANGELOG))
 - [ ] [profiles/CHANGELOG.md](https://github.com/Telenav/osrm-backend/blob/master/profiles/CHANGELOG.md) entry if any `Lua` changes   
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)


## Prerequirements
- Want to contribute? Great! First, please read this page [Contribution Guidelines](https://github.com/Telenav/osrm-backend/wiki/Contribution-Guidelines).    
- If your PR is still work in progress please attach the relevant label.    
