### PR TITLE
feat: adjust epsilon for util/floatequals

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -18,6 +18,7 @@ Changes from v10.2.0
   - ADDED package `util/appversion` to share versioning among many golang binaries [#328](https://github.com/Telenav/osrm-backend/pull/328)
   - ADDED package `stationconnquerier` which builds station connectivity graph based on pre-build data [#323](https://github.com/Telenav/osrm-backend/pull/323)
   - CHANGED for internal refactoring, use `osrm.xxx` to invoke OSRM APIs, e.g. `osrm.Coordinate` instead of `coordinate.Coordinate` [#327](https://github.com/Telenav/osrm-backend/pull/327)
+  - CHANGED for epsilon of util/floatequals, use different epsilon for float32 compare and float64 compare [#332](https://github.com/Telenav/osrm-backend/issues/332)
 
 - Bugfix:    
   - CHANGED `osrm-ranking` parsing of OSRM route response to compatible with `string` array `annotation/nodes` [#296](https://github.com/Telenav/osrm-backend/pull/296)     

--- a/integration/api/oasis/request.go
+++ b/integration/api/oasis/request.go
@@ -126,12 +126,12 @@ func (r *Request) parseQuery(params url.Values) error {
 
 func (r *Request) validate() error {
 	// MaxRange must be set
-	if util.FloatEquals(r.MaxRange, options.InvalidMaxRangeValue) || r.MaxRange < 0 {
+	if util.Float64Equal(r.MaxRange, options.InvalidMaxRangeValue) || r.MaxRange < 0 {
 		return errors.New("Invalid value for " + options.KeyMaxRange + ".")
 	}
 
 	// CurrRange must be set
-	if util.FloatEquals(r.CurrRange, options.InvalidCurrentRangeValue) || r.CurrRange < 0 {
+	if util.Float64Equal(r.CurrRange, options.InvalidCurrentRangeValue) || r.CurrRange < 0 {
 		return errors.New("Invalid value for " + options.KeyCurrRange + ".")
 	}
 

--- a/integration/service/oasis/chargingstrategy/fake_charge_strategy.go
+++ b/integration/service/oasis/chargingstrategy/fake_charge_strategy.go
@@ -46,7 +46,7 @@ func (f *fakeChargeStrategy) EvaluateCost(arrivalEnergy float64, targetState Sta
 	}
 
 	if arrivalEnergy > targetState.Energy ||
-		util.FloatEquals(targetState.Energy, 0.0) {
+		util.Float64Equal(targetState.Energy, 0.0) {
 		return noNeedCharge
 	}
 
@@ -58,7 +58,7 @@ func (f *fakeChargeStrategy) EvaluateCost(arrivalEnergy float64, targetState Sta
 		currentEnergy = sixtyPercentOfMaxEnergy
 	}
 
-	if util.FloatEquals(targetState.Energy, sixtyPercentOfMaxEnergy) {
+	if util.Float64Equal(targetState.Energy, sixtyPercentOfMaxEnergy) {
 		return ChargingCost{
 			Duration: totalTime,
 		}
@@ -69,7 +69,7 @@ func (f *fakeChargeStrategy) EvaluateCost(arrivalEnergy float64, targetState Sta
 		totalTime += energyNeeded4Stage2 / (eightyPercentOfMaxEnergy - sixtyPercentOfMaxEnergy) * 3600.0
 		currentEnergy = eightyPercentOfMaxEnergy
 	}
-	if util.FloatEquals(targetState.Energy, eightyPercentOfMaxEnergy) {
+	if util.Float64Equal(targetState.Energy, eightyPercentOfMaxEnergy) {
 		return ChargingCost{
 			Duration: totalTime,
 		}
@@ -80,7 +80,7 @@ func (f *fakeChargeStrategy) EvaluateCost(arrivalEnergy float64, targetState Sta
 		totalTime += energyNeeded4Stage3 / (f.maxEnergyLevel - eightyPercentOfMaxEnergy) * 7200.0
 	}
 
-	if util.FloatEquals(targetState.Energy, f.maxEnergyLevel) {
+	if util.Float64Equal(targetState.Energy, f.maxEnergyLevel) {
 		return ChargingCost{
 			Duration: totalTime,
 		}

--- a/integration/service/oasis/has_enough_energy_test.go
+++ b/integration/service/oasis/has_enough_energy_test.go
@@ -21,7 +21,7 @@ func TestHasEnoughEnergyPositive1(t *testing.T) {
 	}
 
 	expect := 10000.0
-	if !util.FloatEquals(remainRange, expect) {
+	if !util.Float64Equal(remainRange, expect) {
 		t.Errorf("Incorrect remaining range calculated, expect %s while actual value is %s", strconv.FormatFloat(expect, 'f', -1, 64), strconv.FormatFloat(remainRange, 'f', -1, 64))
 	}
 
@@ -40,7 +40,7 @@ func TestHasEnoughEnergyPositive2(t *testing.T) {
 	}
 
 	expect := 0.0
-	if !util.FloatEquals(remainRange, expect) {
+	if !util.Float64Equal(remainRange, expect) {
 		t.Errorf("Incorrect remaining range calculated, expect %s while actual value is %s", strconv.FormatFloat(expect, 'f', -1, 64), strconv.FormatFloat(remainRange, 'f', -1, 64))
 	}
 }

--- a/integration/service/oasis/haversine/distance_test.go
+++ b/integration/service/oasis/haversine/distance_test.go
@@ -10,7 +10,7 @@ func TestGreatCircleDistance(t *testing.T) {
 	// expect value got from http://www.onlineconversion.com/map_greatcircle_distance.htm
 	expect := 111595.4865288326
 	actual := GreatCircleDistance(32.333, 122.323, 31.333, 122.423)
-	if !util.FloatEquals(expect, actual) {
+	if !util.Float64Equal(expect, actual) {
 		t.Errorf("Expected GreatCircleDistance returns %v, got %v", expect, actual)
 	}
 }

--- a/integration/service/oasis/stationfinder/stationfinderalg/stations_iterator_alg_test.go
+++ b/integration/service/oasis/stationfinder/stationfinderalg/stations_iterator_alg_test.go
@@ -241,10 +241,10 @@ func TestCalculateWeightBetweenNeighbors(t *testing.T) {
 
 		if r.URL.EscapedPath() == "/entity/v4/search/json" {
 			req, _ := nearbychargestation.ParseRequestURL(r.URL)
-			if util.FloatEquals(req.Location.Lat, 2.2) && util.FloatEquals(req.Location.Lon, 2.2) {
+			if util.Float64Equal(req.Location.Lat, 2.2) && util.Float64Equal(req.Location.Lon, 2.2) {
 				var searchResponseBytes4Location1, _ = json.Marshal(nearbychargestation.MockSearchResponse1)
 				w.Write(searchResponseBytes4Location1)
-			} else if util.FloatEquals(req.Location.Lat, 3.3) && util.FloatEquals(req.Location.Lon, 3.3) {
+			} else if util.Float64Equal(req.Location.Lat, 3.3) && util.Float64Equal(req.Location.Lon, 3.3) {
 				var searchResponseBytes4Location2, _ = json.Marshal(nearbychargestation.MockSearchResponse3)
 				w.Write(searchResponseBytes4Location2)
 			}

--- a/integration/service/oasis/stationgraph/station_graph_test.go
+++ b/integration/service/oasis/stationgraph/station_graph_test.go
@@ -204,17 +204,17 @@ func TestStationGraphGenerateSolutions1(t *testing.T) {
 	}
 	sol := solutions[0]
 	// 58.8 = 11.1 + 14.4 + 33.3
-	if !util.FloatEquals(sol.Distance, 58.8) {
+	if !util.Float64Equal(sol.Distance, 58.8) {
 		t.Errorf("Incorrect distance calculated for fakeGraph1 expect 58.89 but got %#v.\n", sol.Distance)
 	}
 
 	// 7918.8 = 11.1 + 2532(60% charge) + 14.4 + 5328(80% charge) + 33.3
-	if !util.FloatEquals(sol.Duration, 7918.8) {
+	if !util.Float64Equal(sol.Duration, 7918.8) {
 		t.Errorf("Incorrect duration calculated for fakeGraph1 expect 10858.8 but got %#v.\n", sol.Duration)
 	}
 
 	// 6.7 = 40 - 33.3
-	if !util.FloatEquals(sol.RemainingRage, 6.7) {
+	if !util.Float64Equal(sol.RemainingRage, 6.7) {
 		t.Errorf("Incorrect duration calculated for fakeGraph1 expect 10858.8 but got %#v.\n", sol.RemainingRage)
 	}
 

--- a/integration/service/ranking/trafficapplyingmodel/invalid_speed.go
+++ b/integration/service/ranking/trafficapplyingmodel/invalid_speed.go
@@ -12,5 +12,5 @@ const (
 
 // IsInvalidSpeed decide whether the speed is valid(>=0) or not.
 func IsInvalidSpeed(speed float64) bool {
-	return util.FloatEquals(speed, InvalidTrafficSpeedFloat64) || speed < 0
+	return util.Float64Equal(speed, InvalidTrafficSpeedFloat64) || speed < 0
 }

--- a/integration/util/float_operation.go
+++ b/integration/util/float_operation.go
@@ -1,14 +1,27 @@
 package util
 
-const epsilon float64 = 0.00000001
+const (
+	epsilon4Float64 float64 = 0.00000001
+	epsilon4Float32 float64 = 0.00001
+)
 
-// FloatEquals compares two float64 numbers and returns true if they equal to each other
+// Float64Equal compares two float64 numbers and returns true if they equal to each other
 // with precision limit of 0.00000001
 // More information about float numbers:
 // Floating Point Numbers https://users.cs.fiu.edu/~downeyt/cop2400/float.htm
 // What Every Computer Scientist Should Know About Floating-Point Arithmetic https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
-func FloatEquals(a, b float64) bool {
-	if (a-b) < epsilon && (b-a) < epsilon {
+func Float64Equal(a, b float64) bool {
+	return floatEqual(a, b, epsilon4Float64)
+}
+
+// Float32Equal compares two float32 numbers and returns true if they equal to each other
+// with precision limit of 0.00001
+func Float32Equal(a, b float32) bool {
+	return floatEqual(float64(a), float64(b), epsilon4Float32)
+}
+
+func floatEqual(a, b, epsilon float64) bool {
+	if (a-b) < epsilon4Float64 && (b-a) < epsilon4Float64 {
 		return true
 	}
 	return false

--- a/integration/util/float_operation.go
+++ b/integration/util/float_operation.go
@@ -21,7 +21,7 @@ func Float32Equal(a, b float32) bool {
 }
 
 func floatEqual(a, b, epsilon float64) bool {
-	if (a-b) < epsilon4Float64 && (b-a) < epsilon4Float64 {
+	if (a-b) < epsilon && (b-a) < epsilon {
 		return true
 	}
 	return false

--- a/integration/util/float_operation_test.go
+++ b/integration/util/float_operation_test.go
@@ -2,7 +2,7 @@ package util
 
 import "testing"
 
-func TestFloatEquals(t *testing.T) {
+func TestFloat64Equal(t *testing.T) {
 	cases := []struct {
 		num1   float64
 		num2   float64
@@ -46,9 +46,51 @@ func TestFloatEquals(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		actual := FloatEquals(c.num1, c.num2)
+		actual := Float64Equal(c.num1, c.num2)
 		if actual != c.expect {
-			t.Errorf("TestFloatEquals failed with case \n %#v expect \n %#v but got %#v\n", c, c.expect, actual)
+			t.Errorf("TestFloat64Equal failed with case \n %#v expect \n %#v but got %#v\n", c, c.expect, actual)
+		}
+	}
+
+}
+
+func TestFloat32Equal(t *testing.T) {
+	cases := []struct {
+		num1   float32
+		num2   float32
+		expect bool
+	}{
+		{
+			32.33333,
+			32.33333,
+			true,
+		},
+		{
+			32.3332,
+			32.3333,
+			false,
+		},
+		{
+			32.33333,
+			-32.33333,
+			false,
+		},
+		{
+			-32.33333,
+			-32.33333,
+			true,
+		},
+		{
+			-32.3333333,
+			-32.3333334,
+			true,
+		},
+	}
+
+	for _, c := range cases {
+		actual := Float32Equal(c.num1, c.num2)
+		if actual != c.expect {
+			t.Errorf("TestFloat64Equal failed with case \n %#v expect \n %#v but got %#v\n", c, c.expect, actual)
 		}
 	}
 


### PR DESCRIPTION
issue: https://github.com/Telenav/osrm-backend/issues/332

# Issue

- Targeting issue: the issue will be CLOSED once the PR merged. If there is no issue that addresses the problem, please open a corresponding issue and link it here. Uses the [Closes keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close them automatically.     
Closes #332

- Any other related issue? Mention them here.    

## Description    
- Add different function to compare float32 and float64, with different epsilon
- Change function name to Float64Equal         

## Tasklist

 - [x] CHANGELOG-FORK.md entry ([CHANGELOG](https://github.com/Telenav/osrm-backend/wiki/CHANGELOG))
 - [x] [profiles/CHANGELOG.md](https://github.com/Telenav/osrm-backend/blob/master/profiles/CHANGELOG.md) entry if any `Lua` changes   
 - [x] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [x] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)


## Prerequirements
- Want to contribute? Great! First, please read this page [Contribution Guidelines](https://github.com/Telenav/osrm-backend/wiki/Contribution-Guidelines).    
- If your PR is still work in progress please attach the relevant label.    
