### PR TITLE
Enable clang-format check

### DIFF
--- a/.github/workflows/osrm-backend-ci.yml
+++ b/.github/workflows/osrm-backend-ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: clang-format
-        run: docker run --mount "src=$(pwd),dst=/workspace/osrm-backend,type=bind" telenavmap/osrm-backend-dev bash -c "cd /workspace/osrm-backend && ./scripts/format.sh"
+        run: docker run --mount "src=$(pwd),dst=/workspace/osrm-backend,type=bind" telenavmap/osrm-backend-dev bash -c "cd /workspace/osrm-backend && ./scripts/format.sh && ./scripts/error_on_dirty.sh"
   
   ci-linux:
     name: osrm-backend CI ubuntu

--- a/.github/workflows/osrm-backend-ci.yml
+++ b/.github/workflows/osrm-backend-ci.yml
@@ -5,7 +5,6 @@ on:
     branches: 
       - 'master'
       - 'release/**'      
-      - 'feature/ci-clang-format'
   pull_request:
     types: [opened, synchronize, reopened]
     branches: 

--- a/.github/workflows/osrm-backend-ci.yml
+++ b/.github/workflows/osrm-backend-ci.yml
@@ -5,6 +5,7 @@ on:
     branches: 
       - 'master'
       - 'release/**'      
+      - 'feature/ci-clang-format'
   pull_request:
     types: [opened, synchronize, reopened]
     branches: 

--- a/.github/workflows/osrm-backend-ci.yml
+++ b/.github/workflows/osrm-backend-ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: clang-format
-        run: docker run --mount "src=$(pwd),dst=/workspace/osrm-backend,type=bind" telenavmap/osrm-backend-dev "cd /workspace/osrm-backend && ./scripts/format.sh"
+        run: docker run --mount "src=$(pwd),dst=/workspace/osrm-backend,type=bind" telenavmap/osrm-backend-dev bash -c "cd /workspace/osrm-backend && ./scripts/format.sh"
   
   ci-linux:
     name: osrm-backend CI ubuntu

--- a/.github/workflows/osrm-backend-ci.yml
+++ b/.github/workflows/osrm-backend-ci.yml
@@ -19,6 +19,14 @@ on:
 
 jobs:
 
+  ci-clang-format:
+    name: osrm-backend check codes format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: clang-format
+        run: docker run --mount "src=$(pwd),dst=/workspace/osrm-backend,type=bind" telenavmap/osrm-backend-dev "cd /workspace/osrm-backend && ./scripts/format.sh"
+  
   ci-linux:
     name: osrm-backend CI ubuntu
     runs-on: ubuntu-latest

--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -17,6 +17,7 @@ Changes from v10.3.0
 - Tools:    
    - CHANGED osrm-backend-dev base image to `debian:buster-slim` and `go1.15.3`(has NOT been enabled for `osrm-backend` yet) [#374](https://github.com/Telenav/osrm-backend/issues/374)
    - CHANGED osrm-backend-dev base image to support Cucumber test(downgrade to `debian:stretch-slim` for `gcc-6`, install `node 10`) [#379](https://github.com/Telenav/osrm-backend/issues/379)
+   - ADDED source code format check [#383](https://github.com/Telenav/osrm-backend/issues/383)
 - Docs:    
    - ADDED document `oasis architecture design` [#360](https://github.com/Telenav/osrm-backend/pull/360)
    - ADDED document `charge station based routing` [#367](https://github.com/Telenav/osrm-backend/pull/367)

--- a/include/customizer/cell_customizer.hpp
+++ b/include/customizer/cell_customizer.hpp
@@ -1,10 +1,10 @@
 #ifndef OSRM_CELLS_CUSTOMIZER_HPP
 #define OSRM_CELLS_CUSTOMIZER_HPP
 
+#include "customizer/cell_update_record.hpp"
 #include "partitioner/cell_storage.hpp"
 #include "partitioner/multi_level_partition.hpp"
 #include "util/query_heap.hpp"
-#include "customizer/cell_update_record.hpp"
 
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/parallel_for.h>
@@ -133,7 +133,7 @@ class CellCustomizer
                                       if (cell_update_record.Check(level, id))
                                       {
                                           Customize(
-                                          graph, heap, cells, allowed_nodes, metric, level, id);
+                                              graph, heap, cells, allowed_nodes, metric, level, id);
                                       }
                                   }
                               });

--- a/include/customizer/cell_update_record.hpp
+++ b/include/customizer/cell_update_record.hpp
@@ -1,14 +1,14 @@
 #ifndef OSRM_CELLS_UPDATED_RECORD_HPP
 #define OSRM_CELLS_UPDATED_RECORD_HPP
 
-#include "util/log.hpp"
-#include "updater/updater.hpp"
 #include "partitioner/multi_level_partition.hpp"
+#include "updater/updater.hpp"
+#include "util/log.hpp"
 
 #include "tbb/concurrent_unordered_set.h"
-#include <vector>
-#include <unordered_set>
 #include <iomanip>
+#include <unordered_set>
+#include <vector>
 
 namespace osrm
 {
@@ -19,13 +19,13 @@ namespace detail
 
 class CellUpdateRecordImpl
 {
-//using CellIDSet = std::unordered_set<CellID>
-using CellIDSet = tbb::concurrent_unordered_set<CellID>;
-using MultiLevelCellIDSet = std::vector<CellIDSet>;
-public:
-    CellUpdateRecordImpl(const partitioner::MultiLevelPartition& mlp, bool incremental)
-    : partition(mlp),
-      isIncremental(incremental)
+    // using CellIDSet = std::unordered_set<CellID>
+    using CellIDSet = tbb::concurrent_unordered_set<CellID>;
+    using MultiLevelCellIDSet = std::vector<CellIDSet>;
+
+  public:
+    CellUpdateRecordImpl(const partitioner::MultiLevelPartition &mlp, bool incremental)
+        : partition(mlp), isIncremental(incremental)
     {
         MultiLevelCellIDSet tmp(partition.GetNumberOfLevels() - 1, CellIDSet());
         cellsets = std::move(tmp);
@@ -38,11 +38,11 @@ public:
             return;
         }
 
-        for (const auto& n : *node_updated)
+        for (const auto &n : *node_updated)
         {
             for (std::size_t level = 1; level < partition.GetNumberOfLevels(); ++level)
             {
-                cellsets[level-1].insert(partition.GetCell(level, n));
+                cellsets[level - 1].insert(partition.GetCell(level, n));
             }
         }
     }
@@ -55,13 +55,13 @@ public:
             return true;
         }
 
-        if (l < 1 || (l - 1) >= static_cast<LevelID>(cellsets.size())) 
+        if (l < 1 || (l - 1) >= static_cast<LevelID>(cellsets.size()))
         {
-            util::Log(logERROR) << "Incorrect level be passed to" 
-                                << typeid(*this).name() << "::" << __func__;
+            util::Log(logERROR) << "Incorrect level be passed to" << typeid(*this).name()
+                                << "::" << __func__;
             return false;
         }
-        return (cellsets[l-1].find(c) != cellsets[l-1].end());
+        return (cellsets[l - 1].find(c) != cellsets[l - 1].end());
     }
 
     void Clear()
@@ -74,7 +74,7 @@ public:
 
     std::string Statistic() const
     {
-        if (!isIncremental) 
+        if (!isIncremental)
         {
             return "Nothing has been recorded in cell_update_record.\n";
         }
@@ -109,22 +109,20 @@ public:
             ss << ") be updated.";
 
             float percentage = (float)(sumOfUpdates * 100) / sumOfCells;
-            ss <<std::setprecision(4) << "  About " << percentage << "% in total.\n";
+            ss << std::setprecision(4) << "  About " << percentage << "% in total.\n";
 
             return ss.str();
         }
     }
 
-private:
-    MultiLevelCellIDSet                     cellsets;
-    const partitioner::MultiLevelPartition  &partition;
-    bool                                    isIncremental;
+  private:
+    MultiLevelCellIDSet cellsets;
+    const partitioner::MultiLevelPartition &partition;
+    bool isIncremental;
 };
-
 }
 
 using CellUpdateRecord = detail::CellUpdateRecordImpl;
-
 }
 }
 

--- a/include/partitioner/multi_level_partition.hpp
+++ b/include/partitioner/multi_level_partition.hpp
@@ -95,8 +95,8 @@ template <storage::Ownership Ownership> class MultiLevelPartitionImpl final
     CellID GetCell(LevelID l, NodeID node) const
     {
         // GetCell could be called with original node id from OSM data,
-        // which might not has related cellid 
-        if (node > partition.size() || l > GetNumberOfLevels()) 
+        // which might not has related cellid
+        if (node > partition.size() || l > GetNumberOfLevels())
             return INVALID_CELL_ID;
         auto p = partition[node];
         auto lidx = LevelIDToIndex(l);

--- a/include/updater/updater.hpp
+++ b/include/updater/updater.hpp
@@ -1,9 +1,9 @@
 #ifndef OSRM_UPDATER_UPDATER_HPP
 #define OSRM_UPDATER_UPDATER_HPP
 
-#include "updater/updater_config.hpp"
 #include "extractor/edge_based_edge.hpp"
 #include "tbb/concurrent_unordered_set.h"
+#include "updater/updater_config.hpp"
 
 #include <chrono>
 #include <vector>

--- a/include/updater/updater_config.hpp
+++ b/include/updater/updater_config.hpp
@@ -57,8 +57,7 @@ struct UpdaterConfig final : storage::IOConfig
                     ".osrm.enw"},
                    {},
                    {".osrm.datasource_names"}),
-          valid_now(0),
-          incremental(false)
+          valid_now(0), incremental(false)
     {
     }
 

--- a/src/tools/customize.cpp
+++ b/src/tools/customize.cpp
@@ -71,9 +71,10 @@ return_code parseArguments(int argc,
             "Required for conditional turn restriction parsing, provide a geojson file containing "
             "time zone boundaries")(
             "incremental",
-            boost::program_options::value<bool>(&customization_config.updater_config.incremental)->default_value(false),
-            "Setting incremental to true means reuse matrix table be calculated before and only customize cells with incremental traffic."
-            );
+            boost::program_options::value<bool>(&customization_config.updater_config.incremental)
+                ->default_value(false),
+            "Setting incremental to true means reuse matrix table be calculated before and only "
+            "customize cells with incremental traffic.");
 
     // hidden options, will be allowed on command line, but will not be
     // shown to the user

--- a/src/updater/updater.cpp
+++ b/src/updater/updater.cpp
@@ -145,13 +145,13 @@ void checkWeightsConsistency(
 
 static const constexpr std::size_t LUA_SOURCE = 0;
 
-void recordsUpdatedNodes(NodeSetPtr& node_updated, const NodeID n)
+void recordsUpdatedNodes(NodeSetPtr &node_updated, const NodeID n)
 {
     if (node_updated)
     {
-       node_updated->insert(n);
+        node_updated->insert(n);
     }
- }
+}
 
 tbb::concurrent_vector<GeometryID>
 updateSegmentData(const UpdaterConfig &config,
@@ -667,7 +667,8 @@ Updater::LoadAndUpdateEdgeExpandedGraph(std::vector<extractor::EdgeBasedEdge> &e
                        });
     }
 
-    // @Telenav, after the modification of #49, conditional_turns related cell will also need to be adjusted
+    // @Telenav, after the modification of #49, conditional_turns related cell will also need to be
+    // adjusted
     if (update_conditional_turns)
     {
         // initialize instance of class that handles time zone resolution

--- a/unit_tests/customizer/cell_customization.cpp
+++ b/unit_tests/customizer/cell_customization.cpp
@@ -119,7 +119,6 @@ BOOST_AUTO_TEST_CASE(two_level_test)
     CHECK_EQUAL_RANGE(cell_1_1.GetInWeight(3), 1, 0);
 }
 
-
 BOOST_AUTO_TEST_CASE(two_level_test2)
 {
     // 0 --- 1

--- a/unit_tests/customizer/cell_update_record.cpp
+++ b/unit_tests/customizer/cell_update_record.cpp
@@ -1,7 +1,7 @@
 #include "common/range_tools.hpp"
 
-#include "customizer/cell_update_record.hpp"
 #include "customizer/cell_customizer.hpp"
+#include "customizer/cell_update_record.hpp"
 #include "partitioner/multi_level_graph.hpp"
 #include "partitioner/multi_level_partition.hpp"
 #include "util/static_graph.hpp"
@@ -73,9 +73,9 @@ BOOST_AUTO_TEST_CASE(cell_update_record_basic_test)
 
     BOOST_REQUIRE_EQUAL(mlp.GetNumberOfLevels(), 3);
 
-    std::vector<MockEdge> edges = {{0, 1, 1}, {0, 2, 1}, {2, 3, 1}, {3, 1, 1}, 
-                                   {2, 4, 1}, {3, 5, 1}, {5, 3, 1}, {4, 5, 1}};
-    
+    std::vector<MockEdge> edges = {
+        {0, 1, 1}, {0, 2, 1}, {2, 3, 1}, {3, 1, 1}, {2, 4, 1}, {3, 5, 1}, {5, 3, 1}, {4, 5, 1}};
+
     auto graph = makeGraph(mlp, edges);
     std::vector<bool> node_filter(true, graph.GetNumberOfNodes());
 
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(cell_update_record_basic_test)
 
     auto cell_1_0 = storage_rec.GetCell(metric_rec, 1, 0);
     auto cell_1_1 = storage_rec.GetCell(metric_rec, 1, 1);
-    //auto cell_2_0 = storage_rec.GetCell(metric_rec, 2, 0);
+    // auto cell_2_0 = storage_rec.GetCell(metric_rec, 2, 0);
 
     // level 1
     CHECK_EQUAL_RANGE(cell_1_0.GetSourceNodes(), 0);
@@ -129,7 +129,6 @@ BOOST_AUTO_TEST_CASE(cell_update_record_test_check)
     BOOST_REQUIRE_EQUAL(cr.Check(2, 0), true);
 }
 
-
 BOOST_AUTO_TEST_CASE(cell_update_record_with_cost_update)
 {
     // 0 --- 1 --- 4
@@ -144,9 +143,9 @@ BOOST_AUTO_TEST_CASE(cell_update_record_with_cost_update)
 
     // update cost {2, 3, 2}
     // A better way to test is updating cost in the graph after initial customization
-    std::vector<MockEdge> edges = {{0, 1, 1}, {0, 2, 1}, {2, 3, 1}, {3, 1, 1}, 
-                                   {2, 4, 1}, {3, 5, 1}, {5, 3, 1}, {4, 5, 1}};
-    
+    std::vector<MockEdge> edges = {
+        {0, 1, 1}, {0, 2, 1}, {2, 3, 1}, {3, 1, 1}, {2, 4, 1}, {3, 5, 1}, {5, 3, 1}, {4, 5, 1}};
+
     auto graph = makeGraph(mlp, edges);
     std::vector<bool> node_filter(true, graph.GetNumberOfNodes());
     CellStorage storage_rec(mlp, graph);
@@ -169,8 +168,8 @@ BOOST_AUTO_TEST_CASE(cell_update_record_with_cost_update)
     // Init graph 2
     // update cost {2, 3, 2}
     // A better way to test is updating cost in the graph after initial customization
-    std::vector<MockEdge> edges2 = {{0, 1, 1}, {0, 2, 1}, {2, 3, 2}, {3, 1, 1}, 
-                                   {2, 4, 1}, {3, 5, 1}, {5, 3, 1}, {4, 5, 1}};
+    std::vector<MockEdge> edges2 = {
+        {0, 1, 1}, {0, 2, 1}, {2, 3, 2}, {3, 1, 1}, {2, 4, 1}, {3, 5, 1}, {5, 3, 1}, {4, 5, 1}};
     auto graph2 = makeGraph(mlp, edges2);
 
     updater::NodeSetPtr ss = std::make_shared<updater::NodeSet>();
@@ -188,8 +187,9 @@ BOOST_AUTO_TEST_CASE(cell_update_record_with_cost_update)
     CHECK_EQUAL_RANGE(cell_1_1.GetOutWeight(3), 0);
     CHECK_EQUAL_RANGE(cell_1_1.GetInWeight(3), 2, 0);
 
-    BOOST_REQUIRE_EQUAL(cr2.Statistic(), "Cell Update Status(count for levels): (1,1) of (2,1) be updated.  About 66.67% in total.\n");
+    BOOST_REQUIRE_EQUAL(cr2.Statistic(),
+                        "Cell Update Status(count for levels): (1,1) of (2,1) be "
+                        "updated.  About 66.67% in total.\n");
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-

--- a/unit_tests/updater/concurrent_node_set.cpp
+++ b/unit_tests/updater/concurrent_node_set.cpp
@@ -8,7 +8,6 @@ BOOST_AUTO_TEST_SUITE(concurrent_node_set_test)
 
 using namespace osrm;
 
-
 BOOST_AUTO_TEST_CASE(node_set_enable_test)
 {
     updater::NodeSetPtr ns = std::make_shared<updater::NodeSet>();


### PR DESCRIPTION
# Issue

- Targeting issue: the issue will be CLOSED once the PR merged. If there is no issue that addresses the problem, please open a corresponding issue and link it here. Uses the [Closes keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close them automatically.     
Closes #383 

- Any other related issue? Mention them here.    

## Description    
A summary description for what the PR achieves.           

- `.h/.cpp` changes only due to format.     
- The PR check will fail if any cpp code doesn't formatted.    

## Tasklist

 - [x] CHANGELOG-FORK.md entry ([CHANGELOG](https://github.com/Telenav/osrm-backend/wiki/CHANGELOG))
 - [ ] [profiles/CHANGELOG.md](https://github.com/Telenav/osrm-backend/blob/master/profiles/CHANGELOG.md) entry if any `Lua` changes   
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)


## Prerequirements
- Want to contribute? Great! First, please read this page [Contribution Guidelines](https://github.com/Telenav/osrm-backend/wiki/Contribution-Guidelines).    
- If your PR is still work in progress please attach the relevant label.    
