### PR TITLE
Fix: build error on mac OS with Apple Clang 12

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -13,6 +13,7 @@ Changes from v10.3.0
   - ADDED parser for `.osrm.restrictions` and `.osrm.cnbg_to_ebg` files [#371](https://github.com/Telenav/osrm-backend/pull/371)
   - ADDED Merge changes of [Project-osrm/osrm-backend v5.23.0 release](https://github.com/Project-OSRM/osrm-backend/releases/tag/v5.23.0) [#377](https://github.com/Telenav/osrm-backend/pull/377)
 - Bugfix:    
+  - FIXED build error on macOS with `Apple Clang 12` [#386](https://github.com/Telenav/osrm-backend/pull/386)
 - Performance:    
 - Tools:    
    - CHANGED osrm-backend-dev base image to `debian:buster-slim` and `go1.15.3`(has NOT been enabled for `osrm-backend` yet) [#374](https://github.com/Telenav/osrm-backend/issues/374)

--- a/src/guidance/segregated_intersection_classification.cpp
+++ b/src/guidance/segregated_intersection_classification.cpp
@@ -226,7 +226,7 @@ std::unordered_set<EdgeID> findSegregatedNodes(const extractor::NodeBasedGraphFa
     auto const collect_edge_info_fn = [&](auto const &edges1, NodeID node2) {
         std::vector<EdgeInfo> info;
 
-        for (auto const &e : edges1)
+        for (auto e : edges1)
         {
             NodeID const target = graph.GetTarget(e);
             if (target == node2)

--- a/src/util/timezones.cpp
+++ b/src/util/timezones.cpp
@@ -154,7 +154,7 @@ boost::optional<struct tm> Timezoner::operator()(const point_t &point) const
 {
     std::vector<rtree_t::value_type> result;
     rtree.query(boost::geometry::index::intersects(point), std::back_inserter(result));
-    for (const auto v : result)
+    for (const auto &v : result)
     {
         const auto index = v.second;
         if (boost::geometry::within(point, local_times[index].first))


### PR DESCRIPTION
# Issue

- Targeting issue: the issue will be CLOSED once the PR merged. If there is no issue that addresses the problem, please open a corresponding issue and link it here. Uses the [Closes keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close them automatically.     
Closes https://github.com/Telenav/osrm-backend/issues/385

- Any other related issue? Mention them here.    

## Description    
A summary description for what the PR achieves.           

Fix build error on latest macOS with Apple Clang 12. Same with https://github.com/Project-OSRM/osrm-backend/pull/5865. 

## Tasklist

 - [x] CHANGELOG-FORK.md entry ([CHANGELOG](https://github.com/Telenav/osrm-backend/wiki/CHANGELOG))
 - [ ] [profiles/CHANGELOG.md](https://github.com/Telenav/osrm-backend/blob/master/profiles/CHANGELOG.md) entry if any `Lua` changes   
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)


## Prerequirements
- Want to contribute? Great! First, please read this page [Contribution Guidelines](https://github.com/Telenav/osrm-backend/wiki/Contribution-Guidelines).    
- If your PR is still work in progress please attach the relevant label.    
