### PR TITLE
Fix unmatched speed unit between traffic flow(m/s) and OSRM traffic injection(km/h)

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -14,6 +14,7 @@ Changes from v10.3.0
   - ADDED Merge changes of [Project-osrm/osrm-backend v5.23.0 release](https://github.com/Project-OSRM/osrm-backend/releases/tag/v5.23.0) [#377](https://github.com/Telenav/osrm-backend/pull/377)
 - Bugfix:    
   - FIXED build error on macOS with `Apple Clang 12` [#386](https://github.com/Telenav/osrm-backend/pull/386)
+  - FIXED unmatched speed unit between traffic flow(m/s) and OSRM traffic injection(km/h) [#389](https://github.com/Telenav/osrm-backend/issues/389)
 - Performance:    
 - Tools:    
    - CHANGED osrm-backend-dev base image to `debian:buster-slim` and `go1.15.3`(has NOT been enabled for `osrm-backend` yet) [#374](https://github.com/Telenav/osrm-backend/issues/374)

--- a/integration/cmd/osrm-traffic-updater/osrm_traffic_updater.go
+++ b/integration/cmd/osrm-traffic-updater/osrm_traffic_updater.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Telenav/osrm-backend/integration/traffic/livetraffic/trafficproxy"
 	"github.com/Telenav/osrm-backend/integration/traffic/livetraffic/trafficproxyclient"
+	"github.com/Telenav/osrm-backend/integration/util/speedunit"
 	"github.com/golang/glog"
 )
 
@@ -101,7 +102,7 @@ func trafficData2map(trafficData trafficproxy.TrafficResponse, m map[int64]int) 
 		}
 
 		wayid := flow.Flow.WayID
-		m[wayid] = int(flow.Flow.Speed)
+		m[wayid] = int(speedunit.ConvertMPS2KPH(float64(flow.Flow.GetSpeed()))) // osrm expect km/h but flow stores m/s, see more in https://github.com/Project-OSRM/osrm-backend/wiki/Traffic#traffic-updates
 
 		if wayid > 0 {
 			fwdCnt++

--- a/integration/service/ranking/trafficapplyingmodel/appendspeedonly/model.go
+++ b/integration/service/ranking/trafficapplyingmodel/appendspeedonly/model.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Telenav/osrm-backend/integration/traffic/livetraffic/trafficproxy"
+	"github.com/Telenav/osrm-backend/integration/util/speedunit"
 
 	"github.com/Telenav/osrm-backend/integration/api/osrm/route"
 	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel"
@@ -75,7 +76,7 @@ func (m Model) applyTrafficOnAnnotation(a *route.Annotation, enableLiveTraffic b
 
 		if m.LiveTrafficQuerier != nil && enableLiveTraffic {
 			if f := m.LiveTrafficQuerier.QueryFlow(wayID); f != nil {
-				liveTrafficSpeeds[i] = float64(f.GetSpeed())
+				liveTrafficSpeeds[i] = speedunit.ConvertMPS2KPH(float64(f.GetSpeed())) // osrm expect km/h but flow stores m/s, see more in https://github.com/Project-OSRM/osrm-backend/wiki/Traffic#traffic-updates
 				liveTrafficlevels[i] = int(f.GetTrafficLevel())
 			} else {
 				liveTrafficSpeeds[i] = float64(trafficapplyingmodel.InvalidLiveTrafficSpeed)

--- a/integration/service/ranking/trafficapplyingmodel/appendspeedonly/model_test.go
+++ b/integration/service/ranking/trafficapplyingmodel/appendspeedonly/model_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Telenav/osrm-backend/integration/traffic/livetraffic/trafficproxy"
+	"github.com/Telenav/osrm-backend/integration/util/speedunit"
 
 	"github.com/Telenav/osrm-backend/integration/traffic"
 
@@ -63,7 +64,7 @@ func TestApplyFixedTraffic(t *testing.T) {
 	appliedBlockIncident := make([]bool, waysCount)
 	appliedHistoricalSpeed := make([]float64, waysCount)
 	for i := 0; i < waysCount; i++ {
-		appliedLiveTrafficSpeed[i] = mockFixedSpeed
+		appliedLiveTrafficSpeed[i] = speedunit.ConvertMPS2KPH(float64(float32(speedunit.ConvertKPH2MPS(mockFixedSpeed))))
 		appliedLiveTrafficLevel[i] = int(mockFixedLevel)
 		appliedBlockIncident[i] = false
 		appliedHistoricalSpeed[i] = mockFixedSpeed
@@ -134,7 +135,7 @@ func TestApplyNormalTraffic(t *testing.T) {
 	mockTraffic := mock.NewNormalTraffic()
 
 	appliedLiveTrafficSpeed := []float64{
-		float64(float32(6.110000)), // flow uses float32 to store the speed that will lose some precision
+		speedunit.ConvertMPS2KPH(float64(float32(speedunit.ConvertKPH2MPS(6.110000)))), // flow uses float32 to store the speed and stores m/s inside, which will lose some precision
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
@@ -148,8 +149,8 @@ func TestApplyNormalTraffic(t *testing.T) {
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
-		float64(float32(106.11)),
-		float64(float32(106.11)),
+		speedunit.ConvertMPS2KPH(float64(float32(speedunit.ConvertKPH2MPS(106.11)))),
+		speedunit.ConvertMPS2KPH(float64(float32(speedunit.ConvertKPH2MPS(106.11)))),
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
 	}

--- a/integration/service/ranking/trafficapplyingmodel/internal/mock/fixed_traffic.go
+++ b/integration/service/ranking/trafficapplyingmodel/internal/mock/fixed_traffic.go
@@ -4,15 +4,16 @@ import (
 	"time"
 
 	"github.com/Telenav/osrm-backend/integration/traffic/livetraffic/trafficproxy"
+	"github.com/Telenav/osrm-backend/integration/util/speedunit"
 )
 
 // FixedTraffic implements both traffic.HistoricalSpeedQuerier and traffic.LiveTrafficQuerier but always return fixed speed/level.
 type FixedTraffic struct {
-	fixedSpeed        float64
+	fixedSpeed        float64 // km/h
 	fixedTrafficLevel trafficproxy.TrafficLevel
 }
 
-// NewFixedTraffic creates a new fixed traffic mock object.
+// NewFixedTraffic creates a new fixed traffic mock object.The input speed unit is km/h.
 func NewFixedTraffic(fixedSpeed float64, fixedTrafficLevel trafficproxy.TrafficLevel) FixedTraffic {
 	return FixedTraffic{fixedSpeed, fixedTrafficLevel}
 }
@@ -26,7 +27,7 @@ func (f FixedTraffic) BlockedByIncident(wayID int64) bool {
 func (f FixedTraffic) QueryFlow(wayID int64) *trafficproxy.Flow {
 	return &trafficproxy.Flow{
 		WayID:        wayID,
-		Speed:        float32(f.fixedSpeed),
+		Speed:        float32(speedunit.ConvertKPH2MPS(f.fixedSpeed)), // km/h -> m/s since traffic flow's speed unit is m/s.
 		TrafficLevel: f.fixedTrafficLevel,
 		Timestamp:    1588840770,
 	}

--- a/integration/service/ranking/trafficapplyingmodel/internal/mock/normal_traffic.go
+++ b/integration/service/ranking/trafficapplyingmodel/internal/mock/normal_traffic.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/Telenav/osrm-backend/integration/traffic/livetraffic/trafficproxy"
+	"github.com/Telenav/osrm-backend/integration/util/speedunit"
 )
 
 // NormalTraffic implements both traffic.HistoricalSpeedQuerier and traffic.LiveTrafficQuerier for the OSRMRouteNormal.
@@ -26,8 +27,8 @@ func NewNormalTrafficNoBlock() NormalTraffic {
 		map[int64]struct{}{}, map[int64]*trafficproxy.Flow{}, map[int64]float64{},
 	}
 
-	n.flows[851242314] = &trafficproxy.Flow{WayID: 851242314, Speed: 6.110000, TrafficLevel: trafficproxy.TrafficLevel_SLOW_SPEED, Timestamp: 1579419488000}
-	n.flows[-23704643] = &trafficproxy.Flow{WayID: -23704643, Speed: 106.11, TrafficLevel: trafficproxy.TrafficLevel_FREE_FLOW, Timestamp: 1579419488000}
+	n.flows[851242314] = &trafficproxy.Flow{WayID: 851242314, Speed: float32(speedunit.ConvertKPH2MPS(6.110000)), TrafficLevel: trafficproxy.TrafficLevel_SLOW_SPEED, Timestamp: 1579419488000}
+	n.flows[-23704643] = &trafficproxy.Flow{WayID: -23704643, Speed: float32(speedunit.ConvertKPH2MPS(106.11)), TrafficLevel: trafficproxy.TrafficLevel_FREE_FLOW, Timestamp: 1579419488000}
 	n.historicalspeeds[1234704366] = 20.5
 	n.historicalspeeds[-23704642] = 70.0
 	return n

--- a/integration/service/ranking/trafficapplyingmodel/preferlivetraffic/model_test.go
+++ b/integration/service/ranking/trafficapplyingmodel/preferlivetraffic/model_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Telenav/osrm-backend/integration/service/ranking/trafficapplyingmodel/preferlivetraffic"
 	"github.com/Telenav/osrm-backend/integration/traffic"
 	"github.com/Telenav/osrm-backend/integration/traffic/livetraffic/trafficproxy"
+	"github.com/Telenav/osrm-backend/integration/util/speedunit"
 )
 
 func TestApplyTrafficErrors(t *testing.T) {
@@ -59,7 +60,7 @@ func TestApplyNormalTrafficNoBlock(t *testing.T) {
 	appliedDataSourceNamesNone := append(r.Legs[0].Annotation.Metadata.DataSourceNames)
 
 	appliedLiveTrafficSpeed := []float64{
-		float64(float32(6.110000)), // flow uses float32 to store the speed that will lose some precision
+		speedunit.ConvertMPS2KPH(float64(float32(speedunit.ConvertKPH2MPS(6.110000)))), // flow uses float32 to store the speed that will lose some precision
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
@@ -73,8 +74,8 @@ func TestApplyNormalTrafficNoBlock(t *testing.T) {
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
-		float64(float32(106.11)),
-		float64(float32(106.11)),
+		speedunit.ConvertMPS2KPH(float64(float32(speedunit.ConvertKPH2MPS(106.11)))),
+		speedunit.ConvertMPS2KPH(float64(float32(speedunit.ConvertKPH2MPS(106.11)))),
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
 		float64(trafficapplyingmodel.InvalidLiveTrafficSpeed),
 	}
@@ -129,7 +130,7 @@ func TestApplyNormalTrafficNoBlock(t *testing.T) {
 			mock.NewOSRMRouteNormal(),
 			true, true,
 			appliedLiveTrafficSpeed, appliedLiveTrafficLevel, appliedBlockIncident, appliedHistoricalSpeed,
-			[]float64{float64(float32(6.110000)), 8.9, 20.5, 8.9, 14.3, 14.2, 14.4, 14.6, 14.7, 14, 14.4, 14.7, 14, 14.6, float64(float32(106.11)), float64(float32(106.11)), 70.0, 70.0},
+			[]float64{speedunit.ConvertMPS2KPH(float64(float32(speedunit.ConvertKPH2MPS(6.110000)))), 8.9, 20.5, 8.9, 14.3, 14.2, 14.4, 14.6, 14.7, 14, 14.4, 14.7, 14, 14.6, speedunit.ConvertMPS2KPH(float64(float32(speedunit.ConvertKPH2MPS(106.11)))), speedunit.ConvertMPS2KPH(float64(float32(speedunit.ConvertKPH2MPS(106.11)))), 70.0, 70.0},
 			appliedDataSourceNamesBoth,
 			[]int{2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 1, 1},
 			60.3 + liveTrafficDurationWeightChanges + historicalSpeedDurationWeightChanges,
@@ -149,7 +150,7 @@ func TestApplyNormalTrafficNoBlock(t *testing.T) {
 			mock.NewOSRMRouteNormal(),
 			true, false,
 			appliedLiveTrafficSpeed, appliedLiveTrafficLevel, appliedBlockIncident, nil,
-			[]float64{float64(float32(6.110000)), 8.9, 8.9, 8.9, 14.3, 14.2, 14.4, 14.6, 14.7, 14, 14.4, 14.7, 14, 14.6, float64(float32(106.11)), float64(float32(106.11)), 9, 9},
+			[]float64{speedunit.ConvertMPS2KPH(float64(float32(speedunit.ConvertKPH2MPS(6.110000)))), 8.9, 8.9, 8.9, 14.3, 14.2, 14.4, 14.6, 14.7, 14, 14.4, 14.7, 14, 14.6, speedunit.ConvertMPS2KPH(float64(float32(speedunit.ConvertKPH2MPS(106.11)))), speedunit.ConvertMPS2KPH(float64(float32(speedunit.ConvertKPH2MPS(106.11)))), 9, 9},
 			appliedDataSourceNamesLiveTraffic,
 			[]int{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0},
 			60.3 + liveTrafficDurationWeightChanges,

--- a/integration/util/speedunit/converter.go
+++ b/integration/util/speedunit/converter.go
@@ -1,0 +1,16 @@
+// Package speedunit provides speed unit converters.
+package speedunit
+
+const (
+	mps2KPH = 3.6
+)
+
+// ConvertMPS2KPH converts speed from meter per second to kilometers per hour.
+func ConvertMPS2KPH(speed float64) float64 {
+	return speed * mps2KPH
+}
+
+// ConvertKPH2MPS converts speed from kilometers per hour to meter per second.
+func ConvertKPH2MPS(speed float64) float64 {
+	return speed / mps2KPH
+}

--- a/integration/util/speedunit/converter_test.go
+++ b/integration/util/speedunit/converter_test.go
@@ -1,0 +1,31 @@
+package speedunit
+
+import (
+	"testing"
+
+	"github.com/Telenav/osrm-backend/integration/util"
+)
+
+func TestConvert(t *testing.T) {
+
+	cases := []struct {
+		mps float64
+		kph float64
+	}{
+		{0, 0},
+		{1, 3.6},
+		{30, 108},
+	}
+
+	for _, c := range cases {
+		gotKPH := ConvertMPS2KPH(c.mps)
+		if !util.Float64Equal(c.kph, gotKPH) {
+			t.Errorf("ConvertMPS2KPH %f got %f but expect %f", c.mps, gotKPH, c.kph)
+		}
+
+		gotMPS := ConvertKPH2MPS(c.kph)
+		if !util.Float64Equal(c.mps, gotMPS) {
+			t.Errorf("ConvertKPH2MPS %f got %f but expect %f", c.kph, gotMPS, c.mps)
+		}
+	}
+}


### PR DESCRIPTION
# Issue

- Targeting issue: the issue will be CLOSED once the PR merged. If there is no issue that addresses the problem, please open a corresponding issue and link it here. Uses the [Closes keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close them automatically.     
Closes https://github.com/Telenav/osrm-backend/issues/389

- Any other related issue? Mention them here.    

## Description    
A summary description for what the PR achieves.           

## Tasklist

 - [x] CHANGELOG-FORK.md entry ([CHANGELOG](https://github.com/Telenav/osrm-backend/wiki/CHANGELOG))
 - [ ] [profiles/CHANGELOG.md](https://github.com/Telenav/osrm-backend/blob/master/profiles/CHANGELOG.md) entry if any `Lua` changes   
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)


## Prerequirements
- Want to contribute? Great! First, please read this page [Contribution Guidelines](https://github.com/Telenav/osrm-backend/wiki/Contribution-Guidelines).    
- If your PR is still work in progress please attach the relevant label.    
