### PR TITLE
osrm-rankd startup

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -14,6 +14,7 @@ Changes from v10.3.0
   - ADDED Merge changes of [Project-osrm/osrm-backend v5.23.0 release](https://github.com/Project-OSRM/osrm-backend/releases/tag/v5.23.0) [#377](https://github.com/Telenav/osrm-backend/pull/377)
   - ADDED filter invalid OSM ways [#387](https://github.com/Telenav/osrm-backend/issues/387)
   - ADDED re-customize traffic [#395](https://github.com/Telenav/osrm-backend/pull/395)
+  - ADDED `osrm-rankd` launch script [#396](https://github.com/Telenav/osrm-backend/pull/396)
 - Bugfix:    
   - FIXED build error on macOS with `Apple Clang 12` [#386](https://github.com/Telenav/osrm-backend/pull/386)
   - FIXED unmatched speed unit between traffic flow(m/s) and OSRM traffic injection(km/h) [#389](https://github.com/Telenav/osrm-backend/issues/389)

--- a/docker-orchestration/osrm-backend-within-mapdata/README.md
+++ b/docker-orchestration/osrm-backend-within-mapdata/README.md
@@ -76,3 +76,13 @@ $ docker run -d -p 5000:5000 [ENV_OPTIONS] telenavmap/osrm-backend-within-mapdat
 $ # example
 $ docker run -d -p 5000:5000 -e TRAFFIC_PROXY_ENDPOINT=${YOUR_TRAFFIC_PROXY_ENDPOINT} -e TRAFFIC_PROVIDER=${YOUR_TRAFFIC_PROVIDER} -e REGION=${YOUR_REGION} telenavmap/osrm-backend-within-mapdata routed_startup
 ```
+
+## Run osrm-rankd
+
+
+```bash
+$ docker run -d -p 5001:5000 --shm-size=64g telenavmap/osrm-backend-within-mapdata rankd_startup -osrm 127.0.0.1:5000
+$ 
+$ # get route with ways in annotations
+$ curl "http://127.0.0.1:5001/route/v1/driving/-115.130556,36.126124;-115.151499,-36.163968?annotations=true"
+```

--- a/docker-orchestration/osrm-backend/README.md
+++ b/docker-orchestration/osrm-backend/README.md
@@ -81,6 +81,12 @@ $ docker logs -f 5b54931c035abaa0d0635cae4539da91e91fca02d1b37426451aa73476dd53f
 [info] running and waiting for requests
 ```
 
+### Ranking service
+
+```bash
+$ docker run -d -p 5001:5000 --shm-size=64g telenavmap/osrm-backend rankd_startup -osrm 127.0.0.1:5000
+```
+
 ### Oasisd service
 
 Image builds `osrm-api-oasisd` binaries, including generating pre-processing data by `place-connectivity-gen`, or start web service of `oasisd`.  

--- a/docker-orchestration/osrm-backend/docker-entrypoint.sh
+++ b/docker-orchestration/osrm-backend/docker-entrypoint.sh
@@ -85,6 +85,11 @@ elif [ "$1" = 'routed_no_traffic_startup' ]; then
   child=$!
   wait "$child"
 
+elif [ "$1" = 'rankd_startup' ]; then
+  SHM_PATH=${SHM_PATH:="/dev/shm"}
+  ${BUILD_PATH}/snappy -i ${DATA_PATH}/${NODES2WAY_DB_FILE}${SNAPPY_SUFFIX} -o ${SHM_PATH}/${NODES2WAY_DB_FILE}
+  ${BUILD_PATH}/osrm-rankd -logtostderr -p 5000 -nodes2way ${SHM_PATH}/${NODES2WAY_DB_FILE} ${@:2}
+
 elif [ "$1" = 'compile_mapdata' ]; then
   #trap _sig SIGKILL SIGTERM SIGHUP SIGINT EXIT
 

--- a/integration/cmd/osrm-rankd/main.go
+++ b/integration/cmd/osrm-rankd/main.go
@@ -38,7 +38,6 @@ func main() {
 		glog.Errorf("Load nodes2way DB failed, err: %v", err)
 		return
 	}
-	monitorContents.Nodes2WayDB = nodes2wayDB.Statistics()
 
 	// prepare historical speeds if available
 	var historicalSpeedCache *historicalspeed.Speeds

--- a/integration/cmd/osrm-rankd/monitor.go
+++ b/integration/cmd/osrm-rankd/monitor.go
@@ -12,7 +12,6 @@ type monitorContents struct {
 	appversion.VersionInfo         `json:"version"`
 	HistoricalSpeedMonitorContents *historicalSpeedMonitorContents `json:"historical speed"`
 	TrafficCacheMonitorContents    *trafficCacheMonitorContents    `json:"live traffic"`
-	Nodes2WayDB                    string                          `json:"nodes2way"`
 	CmdlineArgs                    []string                        `json:"cmdline"`
 }
 
@@ -29,7 +28,7 @@ type historicalSpeedMonitorContents struct {
 
 func newMonitorContents() *monitorContents {
 	return &monitorContents{
-		0, appversion.VersionInfo{}, &historicalSpeedMonitorContents{}, &trafficCacheMonitorContents{}, "", nil,
+		0, appversion.VersionInfo{}, &historicalSpeedMonitorContents{}, &trafficCacheMonitorContents{}, nil,
 	}
 }
 


### PR DESCRIPTION
# Issue

- Targeting issue: the issue will be CLOSED once the PR merged. If there is no issue that addresses the problem, please open a corresponding issue and link it here. Uses the [Closes keyword](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close them automatically.     


- Any other related issue? Mention them here.    

## Description    
A summary description for what the PR achieves.           

- Script to launch `osrm-rankd`
- Remove db monitor to improve `osrm-rankd` launch performance 
- Fix crash issue with flag `historical_speed=true`

## Tasklist

 - [x] CHANGELOG-FORK.md entry ([CHANGELOG](https://github.com/Telenav/osrm-backend/wiki/CHANGELOG))
 - [ ] [profiles/CHANGELOG.md](https://github.com/Telenav/osrm-backend/blob/master/profiles/CHANGELOG.md) entry if any `Lua` changes   
 - [ ] update relevant [Wiki pages](https://github.com/Project-OSRM/osrm-backend/wiki)
 - [ ] add tests (see [testing documentation](https://github.com/Project-OSRM/osrm-backend/blob/master/docs/testing.md)


## Prerequirements
- Want to contribute? Great! First, please read this page [Contribution Guidelines](https://github.com/Telenav/osrm-backend/wiki/Contribution-Guidelines).    
- If your PR is still work in progress please attach the relevant label.    
