### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/autobuild-osrm-backend-dev.yml
+++ b/.github/workflows/autobuild-osrm-backend-dev.yml
@@ -32,7 +32,7 @@ jobs:
       uses: managedkaos/print-env@v1.0
 
     - name: Build & Publish to DockerHub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}
         username: ${{ secrets.TELENAVMAP_DOCKERHUB_USERNAME }}

--- a/.github/workflows/autobuild-osrm-backend.yml
+++ b/.github/workflows/autobuild-osrm-backend.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Environment Printer
       uses: managedkaos/print-env@v1.0
     - name: Build & Publish to DockerHub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.OSRM_BACKEND_IMAGE_NAME }}
         username: ${{ secrets.TELENAVMAP_DOCKERHUB_USERNAME }}
@@ -83,7 +83,7 @@ jobs:
         run: |
           cd ${{ env.OSRM_BACKEND_WITHIN_MAPDATA_DOCKERFILE_PATH }} && mkdir -p ${{ env.COMPILED_DATA_PATH }} && docker run --mount "src=$(pwd)/${{ env.COMPILED_DATA_PATH }},dst=/compiled-data,type=bind" "${{ env.DOCKERHUB_REGISTRY }}/${{ env.OSRM_BACKEND_IMAGE_NAME }}:${{ env.BUILT_OSRM_BACKEND_IMAGE_TAG }}" compile_mapdata "${{ env.SAMPLE_PROFILE }}" "${{ env.SAMPLE_OSM_MAPDATA }}" 
       - name: Build & Publish osrm-backend-within-mapdata to DockerHub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.OSRM_BACKEND_WITHIN_MAPDATA_IMAGE_NAME }}
           username: ${{ secrets.TELENAVMAP_DOCKERHUB_USERNAME }}

--- a/.github/workflows/release-osrm-backend-dev.yml
+++ b/.github/workflows/release-osrm-backend-dev.yml
@@ -29,7 +29,7 @@ jobs:
       uses: managedkaos/print-env@v1.0
 
     - name: Build & Publish to DockerHub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}
         username: ${{ secrets.TELENAVMAP_DOCKERHUB_USERNAME }}

--- a/.github/workflows/release-osrm-backend.yml
+++ b/.github/workflows/release-osrm-backend.yml
@@ -32,7 +32,7 @@ jobs:
       uses: managedkaos/print-env@v1.0
 
     - name: Build & Publish to DockerHub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.DOCKERHUB_REGISTRY }}/${{ env.IMAGE_NAME }}
         username: ${{ secrets.TELENAVMAP_DOCKERHUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore